### PR TITLE
Add dependency on stdlib >= 2.4.0

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,3 +9,4 @@ project_page 'https://github.com/puppetlabs-seteam/puppet-module-splunk'
 
 dependency 'nanliu/staging', '>= 0.3.1'
 dependency 'puppetlabs/inifile', '>= 1.0.0'
+dependency 'puppetlabs/stdlib', '>= 2.4.0'


### PR DESCRIPTION
The splunk module uses the `join()` function but does not have a dependency on stdlib, nor do any of the other dependencies.
