### PR TITLE
Add T&Ps for Splunk indexer and forwarder props and transforms

### DIFF
--- a/lib/puppet/provider/splunk_props/ini_setting.rb
+++ b/lib/puppet/provider/splunk_props/ini_setting.rb
@@ -1,0 +1,15 @@
+Puppet::Type.type(:splunk_props).provide(
+  :ini_setting,
+  # set ini_setting as the parent provider
+  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+) do
+  # hard code the file path (this allows purging)
+  def self.file_path
+    case Facter.value(:osfamily)
+    when 'windows'
+      'C:\Program Files\Splunk\etc\system\local\props.conf'
+    else
+      '/opt/splunk/etc/system/local/props.conf'
+    end
+  end
+end

--- a/lib/puppet/provider/splunk_transforms/ini_setting.rb
+++ b/lib/puppet/provider/splunk_transforms/ini_setting.rb
@@ -1,0 +1,15 @@
+Puppet::Type.type(:splunk_transforms).provide(
+  :ini_setting,
+  # set ini_setting as the parent provider
+  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+) do
+  # hard code the file path (this allows purging)
+  def self.file_path
+    case Facter.value(:osfamily)
+    when 'windows'
+      'C:\Program Files\Splunk\etc\system\local\transforms.conf'
+    else
+      '/opt/splunk/etc/system/local/transforms.conf'
+    end
+  end
+end

--- a/lib/puppet/provider/splunkforwarder_props/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_props/ini_setting.rb
@@ -1,0 +1,15 @@
+Puppet::Type.type(:splunkforwarder_props).provide(
+  :ini_setting,
+  # set ini_setting as the parent provider
+  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+) do
+  # hard code the file path (this allows purging)
+  def self.file_path
+    case Facter.value(:osfamily)
+    when 'windows'
+      'C:\Program Files\SplunkUniversalForwarder\etc\system\local\props.conf'
+    else
+      '/opt/splunkforwarder/etc/system/local/props.conf'
+    end
+  end
+end

--- a/lib/puppet/provider/splunkforwarder_transforms/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_transforms/ini_setting.rb
@@ -1,0 +1,15 @@
+Puppet::Type.type(:splunkforwarder_transforms).provide(
+  :ini_setting,
+  # set ini_setting as the parent provider
+  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+) do
+  # hard code the file path (this allows purging)
+  def self.file_path
+    case Facter.value(:osfamily)
+    when 'windows'
+      'C:\Program Files\SplunkUniversalForwarder\etc\system\local\transforms.conf'
+    else
+      '/opt/splunkforwarder/etc/system/local/transforms.conf'
+    end
+  end
+end

--- a/lib/puppet/type/splunk_props.rb
+++ b/lib/puppet/type/splunk_props.rb
@@ -1,0 +1,24 @@
+Puppet::Type.newtype(:splunk_props) do
+  ensurable
+  newparam(:name, :namevar => true) do
+    desc 'Setting name to manage from inputs.conf'
+  end
+  newproperty(:value) do
+    desc 'The value of the setting to be defined.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+  newproperty(:setting) do
+    desc 'The setting being defined.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+  newproperty(:section) do
+    desc 'The section the setting is defined under.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+end

--- a/lib/puppet/type/splunk_transforms.rb
+++ b/lib/puppet/type/splunk_transforms.rb
@@ -1,0 +1,24 @@
+Puppet::Type.newtype(:splunk_transforms) do
+  ensurable
+  newparam(:name, :namevar => true) do
+    desc 'Setting name to manage from inputs.conf'
+  end
+  newproperty(:value) do
+    desc 'The value of the setting to be defined.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+  newproperty(:setting) do
+    desc 'The setting being defined.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+  newproperty(:section) do
+    desc 'The section the setting is defined under.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+end

--- a/lib/puppet/type/splunkforwarder_props.rb
+++ b/lib/puppet/type/splunkforwarder_props.rb
@@ -1,0 +1,24 @@
+Puppet::Type.newtype(:splunkforwarder_props) do
+  ensurable
+  newparam(:name, :namevar => true) do
+    desc 'Setting name to manage from props.conf'
+  end
+  newproperty(:value) do
+    desc 'The value of the setting to be defined.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+  newproperty(:setting) do
+    desc 'The setting being defined.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+  newproperty(:section) do
+    desc 'The section the setting is defined under.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+end

--- a/lib/puppet/type/splunkforwarder_transforms.rb
+++ b/lib/puppet/type/splunkforwarder_transforms.rb
@@ -1,0 +1,24 @@
+Puppet::Type.newtype(:splunkforwarder_transforms) do
+  ensurable
+  newparam(:name, :namevar => true) do
+    desc 'Setting name to manage from inputs.conf'
+  end
+  newproperty(:value) do
+    desc 'The value of the setting to be defined.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+  newproperty(:setting) do
+    desc 'The setting being defined.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+  newproperty(:section) do
+    desc 'The section the setting is defined under.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+end


### PR DESCRIPTION
The four different kinds of splunk settings that have to be configured for the indexer and the forwarder are inputs, outputs, props, and transforms. This commit adds the props and transforms.
