### PR TITLE
Update the name of the module for PMT install.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,7 @@ be aquired seperately, and the module configured to use it.
 To begin using this module, use the Puppet Module Tool (PMT) from the command
 line to install this module:
 
-`puppet module install seteam-splunk`
+`puppet module install puppetlabs-splunk`
 
 This will place the module into your primary module path if you do not utilize
 the --target-dir directive.


### PR DESCRIPTION
The README still uses the seteam namespace for the install. Use puppetlabs instead.
