### PR TITLE
Adding new default_host parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,7 @@ class splunk (
   $splunkd_port         = $splunk::params::splunkd_port,
   $splunk_user          = $splunk::params::splunk_user,
   $pkg_provider         = $splunk::params::pkg_provider,
+  $default_host         = $splunk::params::default_host,
   $splunkd_listen       = '127.0.0.1',
   $web_port             = '8000',
   $purge_authentication = false,
@@ -96,7 +97,7 @@ class splunk (
   splunk_input { 'default_host':
     section => 'default',
     setting => 'host',
-    value   => $::clientcert,
+    value   => $default_host,
     tag     => 'splunk_server',
   }
   splunk_input { 'default_splunktcp':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -185,6 +185,7 @@ class splunk::params (
     'RedHat':  { $pkg_provider = 'rpm'  }
     'Debian':  { $pkg_provider = 'dpkg' }
     'Solaris': { $pkg_provider = 'sun'  }
+    'Suse':    { $pkg_provider = 'rpm'  }
     default:   { $pkg_provider = undef  } # Don't define a $pkg_provider
   }
 
@@ -227,6 +228,11 @@ class splunk::params (
     }
     'Solaris sun4v': {
       $package_suffix       = "${version}-${build}-solaris-8-sparc.pkg"
+      $forwarder_pkg_name   = 'splunkforwarder'
+      $server_pkg_name      = 'splunk'
+    }
+    'Suse x86_64': {
+      $package_suffix       = "${version}-${build}-linux-2.6-x86_64.rpm"
       $forwarder_pkg_name   = 'splunkforwarder'
       $server_pkg_name      = 'splunk'
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -60,6 +60,9 @@
 #                 |-- splunkforwarder-4.3.2-123586-x64-release.msi
 #                 `-- splunkforwarder-4.3.2-123586-x86-release.msi
 #
+# [*default_host*]
+#   The host identifier that will be used for splunk. Default: $::clientcert
+#
 # Actions:
 #
 #   Declares parameters to be consumed by other classes in the splunk module.
@@ -73,6 +76,7 @@ class splunk::params (
   $splunkd_port         = '8089',
   $logging_port         = '9997',
   $server               = 'splunk',
+  $default_host         = $::clientcert,
   $forwarder_installdir = undef,
   $server_installdir    = undef,
 ) {
@@ -172,7 +176,7 @@ class splunk::params (
     'default_host' => {
       section      => 'default',
       setting      => 'host',
-      value        => "$::clientcert",
+      value        => "$default_host",
       tag          => 'splunk_forwarder'
     }
   }


### PR DESCRIPTION
I know you're not really set up for submissions at this point, but just in case this is helpful, here's a small change I've made to a fork that I'd love to see in the base.  :) 

The 'norm' at our location is to have syslog use the hostname instead of the fqdn.  Setting the sourcetype to syslog will result in those logs having the "correct" hostname, while others may not be parsed and will end up with the fqdn, which makes for more troublesome searches for that host.

TL;DR: setting the default_host rather than using the parsed value means that confusion can be resolved.

I have tested this on CentOS 7.2 and Ubuntu 14.04.

Thanks!
