### PR TITLE
[REVIEW] [MODULES-3520] refactored types and providers and added purging

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -130,7 +130,7 @@ This virtual resource will get collected by the `::splunk::forwarder` class if i
 ### Types
 
 
-* `splunk_config`: This is a meta resource used to configur defaults for all the splunkforwarder and splunk types.
+* `splunk_config`: This is a meta resource used to configur defaults for all the splunkforwarder and splunk types. This type should not be declared directly as it is declared in `splunk::params` and used internally by the types and providers.
 
 * `splunk_authentication`: Used to manage ini settings in [authentication.conf][authentication.conf-docs]
 * `splunk_authorize`: Used to manage ini settings in [authorize.conf][authorize.conf-docs]
@@ -149,6 +149,40 @@ This virtual resource will get collected by the `::splunk::forwarder` class if i
 * `splunkforwarder_props`: Used to manage ini settings in [props.conf][props.conf-docs]
 * `splunkforwarder_transforms`: Used to manage ini settings in [transforms.conf][transforms.conf-docs]
 * `splunkforwarder_web`: Used to manage ini settings in [web.conf][web.conf-docs]
+
+All of the above types use `puppetlabs/ini_file` as a parent and are declared in an identical way, and accept the following parameters:
+
+* `section`:  The name of the section in the configuration file
+* `setting`:  The setting to be managed
+* `value`: The value of the setting
+
+Both section and setting are namevars for the types.  Specifying a single string as the title without a forward slash implies that the title is the section to be managed (if the section attribute is not defined).  You can also specify the resource title as `section/setting` and ommit both `section` and `setting` params for a more shortform way of declaring the resource.   Eg:
+
+```puppet
+splunkforwarder_output { 'useless title':
+  section => 'default',
+  setting => 'defaultGroup',
+  value   => 'splunk_9777',
+}
+
+splunkforwarder_output { 'default':
+  setting => 'defaultGroup',
+  value   => 'splunk_9777',
+}
+
+splunkforwarder_output { 'default/defaultGroup':
+  value   => 'splunk_9777',
+}
+```
+
+The above resource declarations will all configure the following entry in `outputs.conf`
+
+```
+[default]
+defaultGroup=splunk_9997
+```
+
+Note: if the section contains forward slashes you should not use it as the resource title and should explicitly declare it with the `section` attribute.
 
 
 ## Parameters
@@ -287,6 +321,18 @@ no longer managed by the splunkforwarder_input type. Default to false.
 ####`purge_outputs`
 *Optional* If set to true, outputs.conf will be purged of configuration that is
 no longer managed by the splunk_output type. Default to false.
+
+####`purge_props`
+*Optional* If set to true, props.conf will be purged of configuration that is
+no longer managed by the splunk_props type. Default to false.
+
+####`purge_transforms`
+*Optional* If set to true, transforms.conf will be purged of configuration that is
+no longer managed by the splunk_transforms type. Default to false.
+
+####`purge_web`
+*Optional* If set to true, web.conf will be purged of configuration that is
+no longer managed by the splunk_web type. Default to false.
 
 ####`pkg_provider`
 *Optional* This will override the default package provider for the package

--- a/lib/puppet/provider/ini_setting/splunk.rb
+++ b/lib/puppet/provider/ini_setting/splunk.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:ini_setting).provide(
   def self.file_path
     raise Puppet::Error, "file_path must be set with splunk_config type before provider can be used" if @file_path.nil?
     raise Puppet::Error, "Child provider class does not support a file_name method" unless self.respond_to?(:file_name)
-    @file_path + "/" + file_name
+    File.join(@file_path, file_name)
   end
 
   def self.set_file_path(path)

--- a/lib/puppet/provider/ini_setting/splunk.rb
+++ b/lib/puppet/provider/ini_setting/splunk.rb
@@ -3,6 +3,8 @@ Puppet::Type.type(:ini_setting).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
 ) do
 
+  confine :true => false # Never automatically select this provider
+
   @file_path = nil
 
   def self.file_path

--- a/lib/puppet/provider/ini_setting/splunk.rb
+++ b/lib/puppet/provider/ini_setting/splunk.rb
@@ -1,0 +1,17 @@
+Puppet::Type.type(:ini_setting).provide(
+  :splunk,
+  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+) do
+
+  @file_path = nil
+
+  def self.file_path
+    raise Puppet::Error, "file_path must be set with splunk_config type before provider can be used" if @file_path.nil?
+    raise Puppet::Error, "Child provider class does not support a file_name method" unless self.respond_to?(:file_name)
+    @file_path + "/" + file_name
+  end
+
+  def self.set_file_path(path)
+    @file_path=path
+  end
+end

--- a/lib/puppet/provider/splunk_authentication/ini_setting.rb
+++ b/lib/puppet/provider/splunk_authentication/ini_setting.rb
@@ -1,15 +1,8 @@
 Puppet::Type.type(:splunk_authentication).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-  # hard code the file path (this allows purging)
-  def self.file_path
-    case Facter.value(:osfamily)
-    when 'windows'
-      'C:\Program Files\Splunk\etc\system\local\authentication.conf'
-    else
-      '/opt/splunk/etc/system/local/authentication.conf'
-    end
+  def self.file_name
+    'authentication.conf'
   end
 end

--- a/lib/puppet/provider/splunk_authentication/ini_setting.rb
+++ b/lib/puppet/provider/splunk_authentication/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_authentication).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'authentication.conf'
+    'system/local/authentication.conf'
   end
 end

--- a/lib/puppet/provider/splunk_authorize/ini_setting.rb
+++ b/lib/puppet/provider/splunk_authorize/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_authorize).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'authorize.conf'
+    'system/local/authorize.conf'
   end
 end

--- a/lib/puppet/provider/splunk_authorize/ini_setting.rb
+++ b/lib/puppet/provider/splunk_authorize/ini_setting.rb
@@ -1,15 +1,8 @@
 Puppet::Type.type(:splunk_authorize).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-  # hard code the file path (this allows purging)
-  def self.file_path
-    case Facter.value(:osfamily)
-    when 'windows'
-      'C:\Program Files\Splunk\etc\system\local\authorize.conf'
-    else
-      '/opt/splunk/etc/system/local/authorize.conf'
-    end
+  def self.file_name
+    'authorize.conf'
   end
 end

--- a/lib/puppet/provider/splunk_distsearch/ini_setting.rb
+++ b/lib/puppet/provider/splunk_distsearch/ini_setting.rb
@@ -1,15 +1,8 @@
 Puppet::Type.type(:splunk_distsearch).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-  # hard code the file path (this allows purging)
-  def self.file_path
-    case Facter.value(:osfamily)
-    when 'windows'
-      'C:\Program Files\Splunk\etc\system\local\distsearch.conf'
-    else
-      '/opt/splunk/etc/system/local/distsearch.conf'
-    end
+  def self.file_name
+    'distsearch.conf'
   end
 end

--- a/lib/puppet/provider/splunk_distsearch/ini_setting.rb
+++ b/lib/puppet/provider/splunk_distsearch/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_distsearch).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'distsearch.conf'
+    'system/local/distsearch.conf'
   end
 end

--- a/lib/puppet/provider/splunk_indexes/ini_setting.rb
+++ b/lib/puppet/provider/splunk_indexes/ini_setting.rb
@@ -1,15 +1,8 @@
 Puppet::Type.type(:splunk_indexes).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-  # hard code the file path (this allows purging)
-  def self.file_path
-    case Facter.value(:osfamily)
-    when 'windows'
-      'C:\Program Files\Splunk\etc\system\local\indexes.conf'
-    else
-      '/opt/splunk/etc/system/local/indexes.conf'
-    end
+  def self.file_name
+    'indexes.conf'
   end
 end

--- a/lib/puppet/provider/splunk_indexes/ini_setting.rb
+++ b/lib/puppet/provider/splunk_indexes/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_indexes).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'indexes.conf'
+    'system/local/indexes.conf'
   end
 end

--- a/lib/puppet/provider/splunk_input/ini_setting.rb
+++ b/lib/puppet/provider/splunk_input/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_input).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'inputs.conf'
+    'system/local/inputs.conf'
   end
 end

--- a/lib/puppet/provider/splunk_input/ini_setting.rb
+++ b/lib/puppet/provider/splunk_input/ini_setting.rb
@@ -1,15 +1,8 @@
 Puppet::Type.type(:splunk_input).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-  # hard code the file path (this allows purging)
-  def self.file_path
-    case Facter.value(:osfamily)
-    when 'windows'
-      'C:\Program Files\Splunk\etc\system\local\inputs.conf'
-    else
-      '/opt/splunk/etc/system/local/inputs.conf'
-    end
+  def self.file_name
+    'inputs.conf'
   end
 end

--- a/lib/puppet/provider/splunk_limits/ini_setting.rb
+++ b/lib/puppet/provider/splunk_limits/ini_setting.rb
@@ -1,15 +1,8 @@
 Puppet::Type.type(:splunk_limits).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-  # hard code the file path (this allows purging)
-  def self.file_path
-    case Facter.value(:osfamily)
-    when 'windows'
-      'C:\Program Files\Splunk\etc\system\local\limits.conf'
-    else
-      '/opt/splunk/etc/system/local/limits.conf'
-    end
+  def self.file_name
+    'limits.conf'
   end
 end

--- a/lib/puppet/provider/splunk_limits/ini_setting.rb
+++ b/lib/puppet/provider/splunk_limits/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_limits).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'limits.conf'
+    'system/local/limits.conf'
   end
 end

--- a/lib/puppet/provider/splunk_output/ini_setting.rb
+++ b/lib/puppet/provider/splunk_output/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_output).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'outputs.conf'
+    'system/local/outputs.conf'
   end
 end

--- a/lib/puppet/provider/splunk_output/ini_setting.rb
+++ b/lib/puppet/provider/splunk_output/ini_setting.rb
@@ -1,15 +1,8 @@
 Puppet::Type.type(:splunk_output).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-  # hard code the file path (this allows purging)
-  def self.file_path
-    case Facter.value(:osfamily)
-    when 'windows'
-      'C:\Program Files\Splunk\etc\system\local\outputs.conf'
-    else
-      '/opt/splunk/etc/system/local/outputs.conf'
-    end
+  def self.file_name
+    'outputs.conf'
   end
 end

--- a/lib/puppet/provider/splunk_props/ini_setting.rb
+++ b/lib/puppet/provider/splunk_props/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_props).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'props.conf'
+    'system/local/props.conf'
   end
 end

--- a/lib/puppet/provider/splunk_props/ini_setting.rb
+++ b/lib/puppet/provider/splunk_props/ini_setting.rb
@@ -1,15 +1,8 @@
 Puppet::Type.type(:splunk_props).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-  # hard code the file path (this allows purging)
-  def self.file_path
-    case Facter.value(:osfamily)
-    when 'windows'
-      'C:\Program Files\Splunk\etc\system\local\props.conf'
-    else
-      '/opt/splunk/etc/system/local/props.conf'
-    end
+  def self.file_name
+    'props.conf'
   end
 end

--- a/lib/puppet/provider/splunk_server/ini_setting.rb
+++ b/lib/puppet/provider/splunk_server/ini_setting.rb
@@ -1,15 +1,8 @@
 Puppet::Type.type(:splunk_server).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-  # hard code the file path (this allows purging)
-  def self.file_path
-    case Facter.value(:osfamily)
-    when 'windows'
-      'C:\Program Files\Splunk\etc\system\local\server.conf'
-    else
-      '/opt/splunk/etc/system/local/server.conf'
-    end
+  def self.file_name
+    'server.conf'
   end
 end

--- a/lib/puppet/provider/splunk_server/ini_setting.rb
+++ b/lib/puppet/provider/splunk_server/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_server).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'server.conf'
+    'system/local/server.conf'
   end
 end

--- a/lib/puppet/provider/splunk_transforms/ini_setting.rb
+++ b/lib/puppet/provider/splunk_transforms/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_transforms).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'transforms.conf'
+    'system/local/transforms.conf'
   end
 end

--- a/lib/puppet/provider/splunk_transforms/ini_setting.rb
+++ b/lib/puppet/provider/splunk_transforms/ini_setting.rb
@@ -1,15 +1,8 @@
 Puppet::Type.type(:splunk_transforms).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-  # hard code the file path (this allows purging)
-  def self.file_path
-    case Facter.value(:osfamily)
-    when 'windows'
-      'C:\Program Files\Splunk\etc\system\local\transforms.conf'
-    else
-      '/opt/splunk/etc/system/local/transforms.conf'
-    end
+  def self.file_name
+    'transforms.conf'
   end
 end

--- a/lib/puppet/provider/splunk_web/ini_setting.rb
+++ b/lib/puppet/provider/splunk_web/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_web).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'web.conf'
+    'system/local/web.conf'
   end
 end

--- a/lib/puppet/provider/splunk_web/ini_setting.rb
+++ b/lib/puppet/provider/splunk_web/ini_setting.rb
@@ -1,15 +1,8 @@
 Puppet::Type.type(:splunk_web).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-  # hard code the file path (this allows purging)
-  def self.file_path
-    case Facter.value(:osfamily)
-    when 'windows'
-      'C:\Program Files\Splunk\etc\system\local\web.conf'
-    else
-      '/opt/splunk/etc/system/local/web.conf'
-    end
+  def self.file_name
+    'web.conf'
   end
 end

--- a/lib/puppet/provider/splunkforwarder_input/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_input/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunkforwarder_input).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'inputs.conf'
+    'system/local/inputs.conf'
   end
 end

--- a/lib/puppet/provider/splunkforwarder_input/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_input/ini_setting.rb
@@ -1,17 +1,8 @@
 Puppet::Type.type(:splunkforwarder_input).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-
-  def self.prefetch(resources)
-    catalog = resources[resources.keys.first].catalog
-    splunk_config = catalog.resources.find{|s| s.type == :splunk_config}
-    confdir = splunk_config['forwarder_confdir'] || raise(Puppet::Error, 'Unknown splunk forwarder confdir')
-    @file_path = File.join(confdir, 'inputs.conf')
-  end
-
-  def self.file_path
-    @file_path
+  def self.file_name
+    'inputs.conf'
   end
 end

--- a/lib/puppet/provider/splunkforwarder_output/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_output/ini_setting.rb
@@ -3,7 +3,7 @@ Puppet::Type.type(:splunkforwarder_output).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    "outputs.conf"
+    "system/local/outputs.conf"
   end
 end
 

--- a/lib/puppet/provider/splunkforwarder_output/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_output/ini_setting.rb
@@ -1,17 +1,9 @@
 Puppet::Type.type(:splunkforwarder_output).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-
-  def self.prefetch(resources)
-    catalog = resources[resources.keys.first].catalog
-    splunk_config = catalog.resources.find{|s| s.type == :splunk_config}
-    confdir = splunk_config['forwarder_confdir'] || raise(Puppet::Error, 'Unknown splunk forwarder confdir')
-    @file_path = File.join(confdir, 'outputs.conf')
-  end
-
-  def self.file_path
-    @file_path
+  def self.file_name
+    "outputs.conf"
   end
 end
+

--- a/lib/puppet/provider/splunkforwarder_props/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_props/ini_setting.rb
@@ -1,17 +1,8 @@
 Puppet::Type.type(:splunkforwarder_props).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-
-  def self.prefetch(resources)
-    catalog = resources[resources.keys.first].catalog
-    splunk_config = catalog.resources.find{|s| s.type == :splunk_config}
-    confdir = splunk_config['forwarder_confdir'] || raise(Puppet::Error, 'Unknown splunk forwarder confdir')
-    @file_path = File.join(confdir, 'props.conf')
-  end
-
-  def self.file_path
-    @file_path
+  def self.file_name
+    'props.conf'
   end
 end

--- a/lib/puppet/provider/splunkforwarder_props/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_props/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunkforwarder_props).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'props.conf'
+    'system/local/props.conf'
   end
 end

--- a/lib/puppet/provider/splunkforwarder_transforms/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_transforms/ini_setting.rb
@@ -1,17 +1,8 @@
 Puppet::Type.type(:splunkforwarder_transforms).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-
-  def self.prefetch(resources)
-    catalog = resources[resources.keys.first].catalog
-    splunk_config = catalog.resources.find{|s| s.type == :splunk_config}
-    confdir = splunk_config['forwarder_confdir'] || raise(Puppet::Error, 'Unknown splunk forwarder confdir')
-    @file_path = File.join(confdir, 'transforms.conf')
-  end
-
-  def self.file_path
-    @file_path
+  def self.file_name
+    'transforms.conf'
   end
 end

--- a/lib/puppet/provider/splunkforwarder_transforms/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_transforms/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunkforwarder_transforms).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'transforms.conf'
+    'system/local/transforms.conf'
   end
 end

--- a/lib/puppet/provider/splunkforwarder_web/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_web/ini_setting.rb
@@ -1,17 +1,8 @@
 Puppet::Type.type(:splunkforwarder_web).provide(
   :ini_setting,
-  # set ini_setting as the parent provider
-  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+  :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
-
-  def self.prefetch(resources)
-    catalog = resources[resources.keys.first].catalog
-    splunk_config = catalog.resources.find{|s| s.type == :splunk_config}
-    confdir = splunk_config['forwarder_confdir'] || raise(Puppet::Error, 'Unknown splunk forwarder confdir')
-    @file_path = File.join(confdir, 'web.conf')
-  end
-
-  def self.file_path
-    @file_path
+  def self.file_name
+    'web.conf'
   end
 end

--- a/lib/puppet/provider/splunkforwarder_web/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_web/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunkforwarder_web).provide(
   :parent => Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'web.conf'
+    'system/local/web.conf'
   end
 end

--- a/lib/puppet/type/splunk_authentication.rb
+++ b/lib/puppet/type/splunk_authentication.rb
@@ -1,24 +1,7 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunk_authentication) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from authentication.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunk authentication settings in authentication.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end
+

--- a/lib/puppet/type/splunk_authentication.rb
+++ b/lib/puppet/type/splunk_authentication.rb
@@ -2,6 +2,6 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunk_authentication) do
   @doc = "Manage splunk authentication settings in authentication.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end
 

--- a/lib/puppet/type/splunk_authentication.rb
+++ b/lib/puppet/type/splunk_authentication.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunk_authentication) do
   @doc = "Manage splunk authentication settings in authentication.conf"

--- a/lib/puppet/type/splunk_authorize.rb
+++ b/lib/puppet/type/splunk_authorize.rb
@@ -1,24 +1,6 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunk_authorize) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from authorize.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunk authorize settings in authorize.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end

--- a/lib/puppet/type/splunk_authorize.rb
+++ b/lib/puppet/type/splunk_authorize.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunk_authorize) do
   @doc = "Manage splunk authorize settings in authorize.conf"

--- a/lib/puppet/type/splunk_authorize.rb
+++ b/lib/puppet/type/splunk_authorize.rb
@@ -2,5 +2,5 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunk_authorize) do
   @doc = "Manage splunk authorize settings in authorize.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end

--- a/lib/puppet/type/splunk_config.rb
+++ b/lib/puppet/type/splunk_config.rb
@@ -1,7 +1,7 @@
 # Require all of our types so the class names are resolvable for purging
 Dir[File.dirname(__FILE__) + '/*.rb'].each do |file| 
     unless file == __FILE__
-      require File.join("puppet", "type", File.basename(file, File.extname(file)))
+      require file
     end
 end
 

--- a/lib/puppet/type/splunk_config.rb
+++ b/lib/puppet/type/splunk_config.rb
@@ -1,3 +1,10 @@
+# Require all of our types so the class names are resolvable for purging
+Dir[File.dirname(__FILE__) + '/*.rb'].each do |file| 
+    unless file == __FILE__
+      require File.join("puppet", "type", File.basename(file, File.extname(file)))
+    end
+end
+
 Puppet::Type.newtype(:splunk_config) do
   newparam(:name, :namevar => true) do
     desc 'splunk config'
@@ -14,4 +21,120 @@ Puppet::Type.newtype(:splunk_config) do
 
   newparam(:server_confdir) do
   end
+
+  ## Generate purge parameters for the splunk_config type
+  [ 
+      :purge_inputs,
+      :purge_outputs,
+      :purge_authentication,
+      :purge_authorize,
+      :purge_distsearch,
+      :purge_indexes,
+      :purge_limits,
+      :purge_props,
+      :purge_server,
+      :purge_transforms,
+      :purge_web,
+      :purge_forwarder_inputs,
+      :purge_forwarder_outputs,
+      :purge_forwarder_props,
+      :purge_forwarder_transforms,
+      :purge_forwarder_web
+  ].each do |p|
+    newparam(p) do
+      newvalues(:true,:false)
+      defaultto :false
+    end
+  end
+
+  # The generate method sets the correct paths for the providers
+  # and spawns any resources that need purging.
+  #
+  def generate
+    set_provider_paths
+
+    resources = Array.new
+
+    {
+      Puppet::Type::Splunk_output               => self[:purge_outputs],
+      Puppet::Type::Splunk_input                => self[:purge_inputs],
+      Puppet::Type::Splunk_authentication       => self[:purge_authentication],
+      Puppet::Type::Splunk_authorize            => self[:purge_authorize],
+      Puppet::Type::Splunk_distsearch           => self[:purge_distsearch],
+      Puppet::Type::Splunk_indexes              => self[:purge_indexes],
+      Puppet::Type::Splunk_props                => self[:purge_props],
+      Puppet::Type::Splunk_server               => self[:purge_server],
+      Puppet::Type::Splunk_transforms           => self[:purge_transforms],
+      Puppet::Type::Splunk_web                  => self[:purge_web],
+      Puppet::Type::Splunkforwarder_input       => self[:purge_forwarder_inputs],
+      Puppet::Type::Splunkforwarder_output      => self[:purge_forwarder_outputs],
+      Puppet::Type::Splunkforwarder_props       => self[:purge_forwarder_props],
+      Puppet::Type::Splunkforwarder_transforms  => self[:purge_forwarder_transforms],
+      Puppet::Type::Splunkforwarder_web         => self[:purge_forwarder_web]
+    }.each do |k,purge|
+      resources.concat(purge_splunk_resources(k)) if purge == :true
+    end
+
+    return resources
+  end
+
+
+  def set_provider_paths
+    [
+      :splunk_authentication,
+      :splunk_authorize,
+      :splunk_distsearch,
+      :splunk_indexes,
+      :splunk_limits,
+      :splunk_output,
+      :splunk_props,
+      :splunk_server,
+      :splunk_transforms,
+      :splunk_web
+    ].each do |res_type|
+      Puppet::Type.type(res_type).provider(:ini_setting).set_file_path(self[:server_confdir])
+    end
+    [
+      :splunkforwarder_input,
+      :splunkforwarder_output,
+      :splunkforwarder_props,
+      :splunkforwarder_transforms,
+      :splunkforwarder_web
+    ].each do |res_type|
+      Puppet::Type.type(res_type).provider(:ini_setting).set_file_path(self[:forwarder_confdir])
+    end
+  end
+    
+  def purge_splunk_resources(klass)
+    type_name = klass.name
+    purge_resources = Array.new
+    puppet_resources = Array.new
+
+    # Search the catalog for resource types matching the provided class
+    # type and build an array of puppet resources matching the namevar
+    # as section/setting
+    #
+    catalog_resources = catalog.resources.select { |r| r.is_a?(klass) }
+    catalog_resources.each do |res|
+      puppet_resources << res[:section] + "/" + res[:setting]
+    end
+
+
+    # Search the configured instances of the class type and purge them if
+    # the instance name (setion/setting) isn't found in puppet_resources
+    #
+    Puppet::Type.type(type_name).instances.each do |instance|
+      unless puppet_resources.include?(instance.name)
+        purge_resources << Puppet::Type.type(type_name).new(
+          :name    => instance.name,
+          :section => instance[:section],
+          :setting => instance[:setting],
+          :ensure => :absent
+        )
+      end
+    end
+
+    return purge_resources
+  end
+    
 end

--- a/lib/puppet/type/splunk_distsearch.rb
+++ b/lib/puppet/type/splunk_distsearch.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunk_distsearch) do
   @doc= "Manage distsearch entries in distsearch.conf"

--- a/lib/puppet/type/splunk_distsearch.rb
+++ b/lib/puppet/type/splunk_distsearch.rb
@@ -1,24 +1,7 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunk_distsearch) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from distsearch.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc= "Manage distsearch entries in distsearch.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end
+

--- a/lib/puppet/type/splunk_distsearch.rb
+++ b/lib/puppet/type/splunk_distsearch.rb
@@ -2,6 +2,6 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunk_distsearch) do
   @doc= "Manage distsearch entries in distsearch.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end
 

--- a/lib/puppet/type/splunk_indexes.rb
+++ b/lib/puppet/type/splunk_indexes.rb
@@ -1,24 +1,7 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunk_indexes) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from indexes.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunk index settings in indexes.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end
+

--- a/lib/puppet/type/splunk_indexes.rb
+++ b/lib/puppet/type/splunk_indexes.rb
@@ -2,6 +2,6 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunk_indexes) do
   @doc = "Manage splunk index settings in indexes.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end
 

--- a/lib/puppet/type/splunk_indexes.rb
+++ b/lib/puppet/type/splunk_indexes.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunk_indexes) do
   @doc = "Manage splunk index settings in indexes.conf"

--- a/lib/puppet/type/splunk_input.rb
+++ b/lib/puppet/type/splunk_input.rb
@@ -1,24 +1,6 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunk_input) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from inputs.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunk input settings in inputs.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end

--- a/lib/puppet/type/splunk_input.rb
+++ b/lib/puppet/type/splunk_input.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunk_input) do
   @doc = "Manage splunk input settings in inputs.conf"

--- a/lib/puppet/type/splunk_input.rb
+++ b/lib/puppet/type/splunk_input.rb
@@ -2,5 +2,5 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunk_input) do
   @doc = "Manage splunk input settings in inputs.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end

--- a/lib/puppet/type/splunk_limits.rb
+++ b/lib/puppet/type/splunk_limits.rb
@@ -1,24 +1,6 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunk_limits) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from limits.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunk limits settings in limits.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end

--- a/lib/puppet/type/splunk_limits.rb
+++ b/lib/puppet/type/splunk_limits.rb
@@ -2,5 +2,5 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunk_limits) do
   @doc = "Manage splunk limits settings in limits.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end

--- a/lib/puppet/type/splunk_limits.rb
+++ b/lib/puppet/type/splunk_limits.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunk_limits) do
   @doc = "Manage splunk limits settings in limits.conf"

--- a/lib/puppet/type/splunk_output.rb
+++ b/lib/puppet/type/splunk_output.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunk_output) do
   @doc = "Manage splunk output settings in outputs.conf"

--- a/lib/puppet/type/splunk_output.rb
+++ b/lib/puppet/type/splunk_output.rb
@@ -2,5 +2,5 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunk_output) do
   @doc = "Manage splunk output settings in outputs.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end

--- a/lib/puppet/type/splunk_output.rb
+++ b/lib/puppet/type/splunk_output.rb
@@ -1,24 +1,6 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunk_output) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from outputs.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunk output settings in outputs.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end

--- a/lib/puppet/type/splunk_props.rb
+++ b/lib/puppet/type/splunk_props.rb
@@ -2,5 +2,5 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunk_props) do
   @doc = "Manage splunk prop settings in props.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end

--- a/lib/puppet/type/splunk_props.rb
+++ b/lib/puppet/type/splunk_props.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunk_props) do
   @doc = "Manage splunk prop settings in props.conf"

--- a/lib/puppet/type/splunk_props.rb
+++ b/lib/puppet/type/splunk_props.rb
@@ -1,24 +1,6 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunk_props) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from props.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunk prop settings in props.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end

--- a/lib/puppet/type/splunk_server.rb
+++ b/lib/puppet/type/splunk_server.rb
@@ -1,24 +1,6 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunk_server) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from server.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunk server settings in server.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end

--- a/lib/puppet/type/splunk_server.rb
+++ b/lib/puppet/type/splunk_server.rb
@@ -2,5 +2,5 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunk_server) do
   @doc = "Manage splunk server settings in server.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end

--- a/lib/puppet/type/splunk_server.rb
+++ b/lib/puppet/type/splunk_server.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunk_server) do
   @doc = "Manage splunk server settings in server.conf"

--- a/lib/puppet/type/splunk_transforms.rb
+++ b/lib/puppet/type/splunk_transforms.rb
@@ -2,5 +2,5 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunk_transforms) do
   @doc = "Manage splunk transforms settings in transforms.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end

--- a/lib/puppet/type/splunk_transforms.rb
+++ b/lib/puppet/type/splunk_transforms.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunk_transforms) do
   @doc = "Manage splunk transforms settings in transforms.conf"

--- a/lib/puppet/type/splunk_transforms.rb
+++ b/lib/puppet/type/splunk_transforms.rb
@@ -1,24 +1,6 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunk_transforms) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from transforms.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunk transforms settings in transforms.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end

--- a/lib/puppet/type/splunk_web.rb
+++ b/lib/puppet/type/splunk_web.rb
@@ -2,5 +2,5 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunk_web) do
   @doc = "Manage splunk web settings in web.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end

--- a/lib/puppet/type/splunk_web.rb
+++ b/lib/puppet/type/splunk_web.rb
@@ -1,24 +1,6 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunk_web) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from web.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunk web settings in web.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end

--- a/lib/puppet/type/splunk_web.rb
+++ b/lib/puppet/type/splunk_web.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunk_web) do
   @doc = "Manage splunk web settings in web.conf"

--- a/lib/puppet/type/splunkforwarder_input.rb
+++ b/lib/puppet/type/splunkforwarder_input.rb
@@ -2,5 +2,5 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunkforwarder_input) do
   @doc = "Manage splunkforwarder input settings in inputs.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end

--- a/lib/puppet/type/splunkforwarder_input.rb
+++ b/lib/puppet/type/splunkforwarder_input.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunkforwarder_input) do
   @doc = "Manage splunkforwarder input settings in inputs.conf"

--- a/lib/puppet/type/splunkforwarder_input.rb
+++ b/lib/puppet/type/splunkforwarder_input.rb
@@ -1,24 +1,6 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunkforwarder_input) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from inputs.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunkforwarder input settings in inputs.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end

--- a/lib/puppet/type/splunkforwarder_output.rb
+++ b/lib/puppet/type/splunkforwarder_output.rb
@@ -3,5 +3,5 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunkforwarder_output) do
   @doc = "Manage splunkforwarder output settings in outputs.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end

--- a/lib/puppet/type/splunkforwarder_output.rb
+++ b/lib/puppet/type/splunkforwarder_output.rb
@@ -1,24 +1,6 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunkforwarder_output) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from outputs.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunkforwarder output settings in outputs.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end

--- a/lib/puppet/type/splunkforwarder_output.rb
+++ b/lib/puppet/type/splunkforwarder_output.rb
@@ -1,4 +1,5 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
+
 
 Puppet::Type.newtype(:splunkforwarder_output) do
   @doc = "Manage splunkforwarder output settings in outputs.conf"

--- a/lib/puppet/type/splunkforwarder_props.rb
+++ b/lib/puppet/type/splunkforwarder_props.rb
@@ -2,5 +2,5 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunkforwarder_props) do
   @doc = "Manage splunkforwarder props settings in props.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end

--- a/lib/puppet/type/splunkforwarder_props.rb
+++ b/lib/puppet/type/splunkforwarder_props.rb
@@ -1,24 +1,6 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunkforwarder_props) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from props.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunkforwarder props settings in props.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end

--- a/lib/puppet/type/splunkforwarder_props.rb
+++ b/lib/puppet/type/splunkforwarder_props.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunkforwarder_props) do
   @doc = "Manage splunkforwarder props settings in props.conf"

--- a/lib/puppet/type/splunkforwarder_transforms.rb
+++ b/lib/puppet/type/splunkforwarder_transforms.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunkforwarder_transforms) do
   @doc = "Manage splunkforwarder transforms settings in transforms.conf"

--- a/lib/puppet/type/splunkforwarder_transforms.rb
+++ b/lib/puppet/type/splunkforwarder_transforms.rb
@@ -1,24 +1,6 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunkforwarder_transforms) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from transforms.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunkforwarder transforms settings in transforms.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end

--- a/lib/puppet/type/splunkforwarder_transforms.rb
+++ b/lib/puppet/type/splunkforwarder_transforms.rb
@@ -2,5 +2,5 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunkforwarder_transforms) do
   @doc = "Manage splunkforwarder transforms settings in transforms.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end

--- a/lib/puppet/type/splunkforwarder_web.rb
+++ b/lib/puppet/type/splunkforwarder_web.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/splunk/type'
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
 
 Puppet::Type.newtype(:splunkforwarder_web) do
   @doc = "Manage splunkforwarder web settings in web.conf"

--- a/lib/puppet/type/splunkforwarder_web.rb
+++ b/lib/puppet/type/splunkforwarder_web.rb
@@ -2,6 +2,6 @@ require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splun
 
 Puppet::Type.newtype(:splunkforwarder_web) do
   @doc = "Manage splunkforwarder web settings in web.conf"
-  PuppetX::Puppetlabs::Splunk::Type.clone(self)
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
 end
 

--- a/lib/puppet/type/splunkforwarder_web.rb
+++ b/lib/puppet/type/splunkforwarder_web.rb
@@ -1,24 +1,7 @@
+require 'puppet_x/puppetlabs/splunk/type'
+
 Puppet::Type.newtype(:splunkforwarder_web) do
-  ensurable
-  newparam(:name, :namevar => true) do
-    desc 'Setting name to manage from web.conf'
-  end
-  newproperty(:value) do
-    desc 'The value of the setting to be defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:setting) do
-    desc 'The setting being defined.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
-  newproperty(:section) do
-    desc 'The section the setting is defined under.'
-    munge do |v|
-      v.to_s.strip
-    end
-  end
+  @doc = "Manage splunkforwarder web settings in web.conf"
+  PuppetX::Puppetlabs::Splunk::Type.clone(self)
 end
+

--- a/lib/puppet_x/puppetlabs/splunk/type.rb
+++ b/lib/puppet_x/puppetlabs/splunk/type.rb
@@ -8,7 +8,8 @@ module PuppetX
 
           type.define_singleton_method(:title_patterns) do
             [
-              [ /^([^\/]*)$/, [ [ :section ] ] ],
+              [ /^([^\/]*)$/,   [ [ :section ] ] ],
+              [ /^(.*\/\/.*)$/, [ [ :section ] ] ],
               [ /^(.*)\/(.*)$/,
                 [
                   [:section, lambda{|x| x} ],

--- a/lib/puppet_x/puppetlabs/splunk/type.rb
+++ b/lib/puppet_x/puppetlabs/splunk/type.rb
@@ -3,7 +3,7 @@ module PuppetX
     module Splunk
       module Type
 
-        def self.clone(type)
+        def self.clone_type(type)
           type.ensurable
 
           type.define_singleton_method(:title_patterns) do

--- a/lib/puppet_x/puppetlabs/splunk/type.rb
+++ b/lib/puppet_x/puppetlabs/splunk/type.rb
@@ -1,0 +1,45 @@
+module PuppetX
+  module Puppetlabs
+    module Splunk
+      module Type
+
+        def self.clone(type)
+          type.ensurable
+
+          type.define_singleton_method(:title_patterns) do
+            [
+              [ /^([^\/]*)$/, [ [ :section ] ] ],
+              [ /^(.*)\/(.*)$/,
+                [
+                  [:section, lambda{|x| x} ],
+                  [:setting, lambda{|x| x} ]
+                ]
+              ]
+            ]
+          end
+          type.newproperty(:value) do
+                desc 'The value of the setting to be defined.'
+                munge do |v|
+                  v.to_s.strip
+                end
+          end
+          type.newparam(:setting) do
+                desc 'The setting being defined.'
+                isnamevar
+                munge do |v|
+                  v.to_s.strip
+                end
+           end
+           type.newparam(:section) do
+                desc 'The section the setting is defined under.'
+                isnamevar
+                munge do |v|
+                  v.to_s.strip
+                end
+           end
+           type.newparam(:name)
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet_x/puppetlabs/splunk/type.rb
+++ b/lib/puppet_x/puppetlabs/splunk/type.rb
@@ -18,24 +18,24 @@ module PuppetX
             ]
           end
           type.newproperty(:value) do
-                desc 'The value of the setting to be defined.'
-                munge do |v|
-                  v.to_s.strip
-                end
+            desc 'The value of the setting to be defined.'
+            munge do |v|
+              v.to_s.strip
+            end
           end
           type.newparam(:setting) do
-                desc 'The setting being defined.'
-                isnamevar
-                munge do |v|
-                  v.to_s.strip
-                end
+            desc 'The setting being defined.'
+            isnamevar
+            munge do |v|
+              v.to_s.strip
+            end
            end
            type.newparam(:section) do
-                desc 'The section the setting is defined under.'
-                isnamevar
-                munge do |v|
-                  v.to_s.strip
-                end
+             desc 'The section the setting is defined under.'
+             isnamevar
+             munge do |v|
+               v.to_s.strip
+             end
            end
            type.newparam(:name)
         end

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -55,6 +55,9 @@ class splunk::forwarder (
   $splunkd_listen    = '127.0.0.1',
   $purge_inputs      = false,
   $purge_outputs     = false,
+  $purge_props       = false,
+  $purge_transforms  = false,
+  $purge_web         = false,
   $pkg_provider      = $splunk::params::pkg_provider,
   $forwarder_confdir = $splunk::params::forwarder_confdir,
   $forwarder_output  = $splunk::params::forwarder_output,
@@ -106,14 +109,16 @@ class splunk::forwarder (
   }
 
   # If the purge parameters have been set, remove all unmanaged entries from
-  # the inputs.conf and outputs.conf files, respectively.
-  if $purge_inputs  {
-    resources { 'splunkforwarder_input':  purge => true; }
-  }
-  if $purge_outputs {
-    resources { 'splunkforwarder_output': purge => true; }
-  }
+  # the respective config files.
 
+  Splunk_config['splunk'] {
+    purge_forwarder_outputs    => $purge_outputs,
+    purge_forwarder_inputs     => $purge_forwarder_inputs,
+    purge_forwarder_props      => $purge_forwarder_props,
+    purge_forwarder_transforms => $purge_forwarder_transforms,
+    purge_forwarder_web        => $purge_forwarder_web
+  }
+  
   # This is a module that supports multiple platforms. For some platforms
   # there is non-generic configuration that needs to be declared in addition
   # to the agnostic resources declared here.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,56 +119,21 @@ class splunk (
     tag => 'splunk_server'
   }
 
-  # If the purge parameters have been set, remove all unmanaged entries from
-  # the inputs.conf and outputs.conf files, respectively.
-  if $purge_authentication  {
-    resources { 'splunk_authentication':  purge => true; }
+
+  # Purge resources if option set
+  Splunk_config['splunk'] {
+    purge_authentication => $purge_authentication,
+    purge_authorize      => $purge_authorize,
+    purge_distsearch     => $purge_distsearch,
+    purge_indexes        => $purge_indexes,
+    purge_inputs         => $purge_inputs,
+    purge_limits         => $purge_limits,
+    purge_outputs        => $purge_outputs,
+    purge_props          => $purge_props,
+    purge_server         => $purge_server,
+    purge_transforms     => $purge_transforms,
+    purge_web            => $purge_web
   }
-
-  if $purge_authorize  {
-    resources { 'splunk_authorize':  purge => true; }
-  }
-
-  if $purge_distsearch  {
-    resources { 'splunk_distsearch':  purge => true; }
-  }
-
-  if $purge_indexes  {
-    resources { 'splunk_indexes':  purge => true; }
-  }
-
-  if $purge_inputs  {
-    resources { 'splunk_input':  purge => true; 
-                'splunkforwarder_input':  purge => true; }
-  }
-
-  if $purge_limits  {
-    resources { 'splunk_limits':  purge => true; }
-  }
-
-  if $purge_outputs {
-    resources { 'splunk_output': purge => true;
-                'splunkforwarder_output': purge => true; }
-  }
-
-  if $purge_props  {
-    resources { 'splunk_props':  purge => true; }
-  }
-
-
-  if $purge_server  {
-    resources { 'splunk_server':  purge => true; }
-  }
-
-
-  if $purge_transforms  {
-    resources { 'splunk_transforms':  purge => true; }
-  }
-
-  if $purge_web  {
-    resources { 'splunk_web':  purge => true; }
-  }
-
   # This is a module that supports multiple platforms. For some platforms
   # there is non-generic configuration that needs to be declared in addition
   # to the agnostic resources declared here.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -103,10 +103,10 @@ class splunk::params (
       $forwarder_service    = [ 'splunk' ]
       $password_config_file = "${forwarder_dir}/etc/passwd"
       $secret_file          = "${forwarder_dir}/etc/splunk.secret"
-      $forwarder_confdir    = "${forwarder_dir}/etc/system/local"
+      $forwarder_confdir    = "${forwarder_dir}/etc"
       $server_src_subdir    = 'splunk/linux'
       $server_service       = [ 'splunk', 'splunkd', 'splunkweb' ]
-      $server_confdir       = "${server_dir}/etc/system/local"
+      $server_confdir       = "${server_dir}/etc"
     }
     'SunOS': {
       $path_delimiter       = '/'
@@ -114,10 +114,10 @@ class splunk::params (
       $forwarder_service    = [ 'splunk' ]
       $password_config_file = "${forwarder_dir}/etc/passwd"
       $secret_file          = "${forwarder_dir}/etc/splunk.secret"
-      $forwarder_confdir    = "${forwarder_dir}/etc/system/local"
+      $forwarder_confdir    = "${forwarder_dir}/etc"
       $server_src_subdir    = 'splunk/solaris'
       $server_service       = [ 'splunk', 'splunkd', 'splunkweb' ]
-      $server_confdir       = "${server_dir}/etc/system/local"
+      $server_confdir       = "${server_dir}/etc"
     }
     'Windows': {
       $path_delimiter       = '\\'
@@ -125,10 +125,10 @@ class splunk::params (
       $password_config_file = 'C:/Program Files/SplunkUniversalForwarder/etc/passwd'
       $secret_file          =  'C:/Program Files/SplunkUniversalForwarder/etc/splunk.secret'
       $forwarder_service    = [ 'SplunkForwarder' ] # UNKNOWN
-      $forwarder_confdir    = "${forwarder_dir}/etc/system/local"
+      $forwarder_confdir    = "${forwarder_dir}/etc"
       $server_src_subdir    = 'splunk/windows'
       $server_service       = [ 'Splunkd', 'SplunkWeb' ] # UNKNOWN
-      $server_confdir       = "${server_dir}/etc/system/local"
+      $server_confdir       = "${server_dir}/etc"
       $forwarder_install_options = [
         'AGREETOLICENSE=Yes',
         'LAUNCHSPLUNK=0',


### PR DESCRIPTION
## Description

This is rather a large PR that refactors a lot of stuff internally, though should keep the existing API to users intact.   It addresses the main issue raised in MODULES-3520 regarding purging.

### Purging
As described in the ticket, purging as it stands does not work well with the new dynamic file_path stuff to allow overriding of the conf file locations.   To use regular `instance()` based purging (eg: with the resources resource) then you have no option other than to have hard coded path names in the providers.  Rather than a trade-off between the two I've taken a similar approach used in other modules to use a the `generate` method of a core type (in this case `splunk_config`) to create resources as absent.  Key things here that have changed are:

* Purging now works in the same consistent way for *all* types across server and forwarder
* File path are defaulted in `params.pp` and the purge options are added to the `splunk_config` type by the classes that inherit from it (`init.pp` and `forwarder.pp`)
* `splunk_config` sets the file paths on the providers based on what `params.pp` has defined
* `splunk_config` uses it's `generate()` function to purge unwanted resources
* Purging is done by comparing the namevars (see below) rather than just the resource refs

### Namevars
Splunk types are a combination of setting and section, with a value.  The current implementation is open to odd behaviour since the namevar is essentially discarded.  This opens up scenarios such as the following.

```puppet
splunkforwarder_output { 'foo':
  ensure => present,
  setting => 'xyz',
  section => 'bar',
  value   => 'tango',
}

splunkforwarder_output { 'bar':
  ensure => present,
  setting => 'xyz',
  section => 'bar',
  value   => 'delta',
}
```

The end result here is that Puppet ends up constantly changing the values because it doesn't see the resource declarations as conflicts.

```
Notice: /Stage[main]/Main/Splunkforwarder_output[foo]/value: value changed 'delta' to 'tango'
Notice: /Stage[main]/Main/Splunkforwarder_output[bar]/value: value changed 'tango' to 'delta'

Notice: /Stage[main]/Main/Splunkforwarder_output[foo]/value: value changed 'delta' to 'tango'
Notice: /Stage[main]/Main/Splunkforwarder_output[bar]/value: value changed 'tango' to 'delta'
```

The solution is to make all the types a composite namevar of `setting` and `section`.   The `name` parameter has been left in because it `Puppet::Type.type(:foo).new` (used for purging) seems not to work if  there is not a name parameter.

Now the above code fails as expected....

```
Error: Cannot alias Splunkforwarder_output[bar] to [nil, "bar", "xyz"] at /home/vagrant/test.pp:33; resource ["Splunkforwarder_output", nil, "bar", "xyz"] already declared at /home/vagrant/test.pp:26
```

### Title patterns
Following on from making the resource type support composite namevars, I've also added a title_pattern that allows for some shorter resource declarations.  This could possibly be viewed as an API change, but I can't think of many circumstances where existing declarations would break. (needs decision).   The new title patterns match `/^([^\/]*)$/` as "section" or `/^(.*)\/(.*)$/` as "section/setting" meaning the following three types of declarations can be used (and do the same thing)

```puppet
splunkforwarder_output { 'useless title':
  ensure => present,
  setting => 'xyz',
  section => 'bar',
  value   => 'tango',
}

splunkforwarder_output { 'bar':
  ensure => present,
  setting => 'xyz',
  value   => 'tango',
}

splunkforwarder_output { 'bar/xyz':
  ensure => present,
  value   => 'tango',
}
```

### Code clean up

Finally, all of the types and providers are identical and do exactly the same thing, the only difference is which file they do it in.  This has resulted in *alot* of duplicated code both in the types and providers.  I've added some boilerplating to this

* Types use a kind of mixin pattern provided by `PuppetX::Puppetlabs::Splunk::Type.clone` so the parameters, properties and methods of the types are centrally managed - but you can still add additional ones, or documentation, to individual types.

* Providers have been simplified a bit, they are only responsible for defining what their filename is, and they inherit from `Puppet::Type.type(:ini_file).provider(:splunk)` where generic stuff around file_path is set (by `splunk_config`).  This then inturn inherits from the `:ini_file` provider in `puppetlabs-inifile`

* 250 fewer lines of code!...  `37 files changed, 439 insertions(+), 689 deletions(-)`


 