### PR TITLE
Notify service from addons

### DIFF
--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -96,6 +96,9 @@ class splunk::forwarder (
   # Declare addons
   create_resources('splunk::addon', $addons)
 
+  # Ensure that the service restarts upon changes to addons
+  Splunk::Addon <||> ~> Service[$virtual_service]
+
   # Declare inputs and outputs specific to the forwarder profile
   $tag_resources = { tag => 'splunk_forwarder' }
   create_resources( 'splunkforwarder_input',$forwarder_input, $tag_resources)


### PR DESCRIPTION
Modifying `Splunk::Addon` defined types doesn't currently notify the splunk service.

This PR adds a collector chain after the invocation of `create_resources` to ensure that they are set to notify the service

