### PR TITLE
added package dependency to splunk::addon types

### DIFF
--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -97,7 +97,7 @@ class splunk::forwarder (
   create_resources('splunk::addon', $addons)
 
   # Ensure that the service restarts upon changes to addons
-  Splunk::Addon <||> ~> Service[$virtual_service]
+  Package[$package_name] -> Splunk::Addon <||> ~> Service[$virtual_service]
 
   # Declare inputs and outputs specific to the forwarder profile
   $tag_resources = { tag => 'splunk_forwarder' }


### PR DESCRIPTION

Further testing after #57 revealed that the package dependancy was also missing causing potential failures with the parent directory of the addon not existing.

In the longer term I am planning to re-engineer a lot of how the dependencies are defined, it's rather over-engineered and the use of virtual resources is pretty overkill - I'll aim to get significant changes into that for 5.1.0 but for now this patch will remove the failure.

