### PR TITLE
Make the file reference use the variable and not a fixed path

### DIFF
--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -159,17 +159,17 @@ class splunk::forwarder (
     mode => '0644',
   }
 
-  file { '/opt/splunkforwarder/etc/system/local/inputs.conf':
+  file { "${forwarder_confdir}/system/local/inputs.conf":
     ensure => file,
     tag    => 'splunk_forwarder',
   }
 
-  file { '/opt/splunkforwarder/etc/system/local/outputs.conf':
+  file { "${forwarder_confdir}/system/local/outputs.conf":
     ensure => file,
     tag    => 'splunk_forwarder',
   }
 
-  file { '/opt/splunkforwarder/etc/system/local/web.conf':
+  file { "${forwarder_confdir}/system/local/web.conf":
     ensure => file,
     tag    => 'splunk_forwarder',
   }


### PR DESCRIPTION
Find it curious that the "file" references in forwarder.pp are not using the variable from the params.pp, small fix. Got the errror when trying to deploy on Windows, but guess it would also occur when using another forwarder_confdir...

For Windows support it seems to me support needs to be added to install the universalforwarder as a chocolatey package, since I don't see how it is gonna work using the msi only...