### PR TITLE
Bump min version_requirement for Puppet + deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,8 +435,7 @@ Not yet implemented.
 
 - Currently tested manually on Centos 7, but we will eventually add automated
   testing and are targeting compatibility with other platforms.
-- Tested with Puppet 4.x but should work with older versions. This will get
-  updated soon.
+- Tested with Puppet 4.x
 
 ## Development
 

--- a/metadata.json
+++ b/metadata.json
@@ -59,21 +59,21 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.8.0 < 5.0.0"
+      "version_requirement": ">= 3.8.7 < 5.0.0"
     }
   ],
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 2.4.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
       "name": "puppetlabs-inifile",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.4.1 < 2.0.0"
     },
     {
       "name": "puppet-staging",
-      "version_requirement": ">= 0.3.1"
+      "version_requirement": ">= 2.0.1 < 3.0.0"
     }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata