### PR TITLE
Allow redirecting of settings into custom contexts

### DIFF
--- a/lib/puppet/provider/ini_setting/splunk.rb
+++ b/lib/puppet/provider/ini_setting/splunk.rb
@@ -14,6 +14,10 @@ Puppet::Type.type(:ini_setting).provide(
   def self.file_path
     raise Puppet::Error, 'file_path must be set with splunk_config type before provider can be used' if @file_path.nil?
     raise Puppet::Error, 'Child provider class does not support a file_name method' unless respond_to?(:file_name)
-    File.join(@file_path, file_name)
+    @file_path
+  end
+
+  def file_path
+    File.join(self.class.file_path, resource[:context], self.class.file_name)
   end
 end

--- a/lib/puppet/provider/splunk_authentication/ini_setting.rb
+++ b/lib/puppet/provider/splunk_authentication/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_authentication).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/authentication.conf'
+    'authentication.conf'
   end
 end

--- a/lib/puppet/provider/splunk_authorize/ini_setting.rb
+++ b/lib/puppet/provider/splunk_authorize/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_authorize).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/authorize.conf'
+    'authorize.conf'
   end
 end

--- a/lib/puppet/provider/splunk_distsearch/ini_setting.rb
+++ b/lib/puppet/provider/splunk_distsearch/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_distsearch).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/distsearch.conf'
+    'distsearch.conf'
   end
 end

--- a/lib/puppet/provider/splunk_indexes/ini_setting.rb
+++ b/lib/puppet/provider/splunk_indexes/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_indexes).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/indexes.conf'
+    'indexes.conf'
   end
 end

--- a/lib/puppet/provider/splunk_input/ini_setting.rb
+++ b/lib/puppet/provider/splunk_input/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_input).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/inputs.conf'
+    'inputs.conf'
   end
 end

--- a/lib/puppet/provider/splunk_limits/ini_setting.rb
+++ b/lib/puppet/provider/splunk_limits/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_limits).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/limits.conf'
+    'limits.conf'
   end
 end

--- a/lib/puppet/provider/splunk_output/ini_setting.rb
+++ b/lib/puppet/provider/splunk_output/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_output).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/outputs.conf'
+    'outputs.conf'
   end
 end

--- a/lib/puppet/provider/splunk_props/ini_setting.rb
+++ b/lib/puppet/provider/splunk_props/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_props).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/props.conf'
+    'props.conf'
   end
 end

--- a/lib/puppet/provider/splunk_server/ini_setting.rb
+++ b/lib/puppet/provider/splunk_server/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_server).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/server.conf'
+    'server.conf'
   end
 end

--- a/lib/puppet/provider/splunk_transforms/ini_setting.rb
+++ b/lib/puppet/provider/splunk_transforms/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_transforms).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/transforms.conf'
+    'transforms.conf'
   end
 end

--- a/lib/puppet/provider/splunk_web/ini_setting.rb
+++ b/lib/puppet/provider/splunk_web/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunk_web).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/web.conf'
+    'web.conf'
   end
 end

--- a/lib/puppet/provider/splunkforwarder_input/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_input/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunkforwarder_input).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/inputs.conf'
+    'inputs.conf'
   end
 end

--- a/lib/puppet/provider/splunkforwarder_output/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_output/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunkforwarder_output).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/outputs.conf'
+    'outputs.conf'
   end
 end

--- a/lib/puppet/provider/splunkforwarder_props/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_props/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunkforwarder_props).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/props.conf'
+    'props.conf'
   end
 end

--- a/lib/puppet/provider/splunkforwarder_transforms/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_transforms/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunkforwarder_transforms).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/transforms.conf'
+    'transforms.conf'
   end
 end

--- a/lib/puppet/provider/splunkforwarder_web/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_web/ini_setting.rb
@@ -3,6 +3,6 @@ Puppet::Type.type(:splunkforwarder_web).provide(
   parent: Puppet::Type.type(:ini_setting).provider(:splunk)
 ) do
   def self.file_name
-    'system/local/web.conf'
+    'web.conf'
   end
 end

--- a/lib/puppet_x/puppetlabs/splunk/type.rb
+++ b/lib/puppet_x/puppetlabs/splunk/type.rb
@@ -36,6 +36,13 @@ module PuppetX
               v.to_s.strip
             end
           end
+          type.newparam(:context) do
+            desc 'The context in which to define the setting.'
+            munge do |v|
+              v.to_s.strip
+            end
+            defaultto('system/local')
+          end
           type.newparam(:name)
         end
       end

--- a/spec/splunk_data.rb
+++ b/spec/splunk_data.rb
@@ -1,24 +1,24 @@
 
 SPLUNK_SERVER_TYPES = {
-  splunk_authentication: 'system/local/authentication.conf',
-  splunk_authorize: 'system/local/authorize.conf',
-  splunk_distsearch: 'system/local/distsearch.conf',
-  splunk_indexes: 'system/local/indexes.conf',
-  splunk_input: 'system/local/inputs.conf',
-  splunk_limits: 'system/local/limits.conf',
-  splunk_output: 'system/local/outputs.conf',
-  splunk_props: 'system/local/props.conf',
-  splunk_server: 'system/local/server.conf',
-  splunk_transforms: 'system/local/transforms.conf',
-  splunk_web: 'system/local/web.conf'
+  splunk_authentication: 'authentication.conf',
+  splunk_authorize: 'authorize.conf',
+  splunk_distsearch: 'distsearch.conf',
+  splunk_indexes: 'indexes.conf',
+  splunk_input: 'inputs.conf',
+  splunk_limits: 'limits.conf',
+  splunk_output: 'outputs.conf',
+  splunk_props: 'props.conf',
+  splunk_server: 'server.conf',
+  splunk_transforms: 'transforms.conf',
+  splunk_web: 'web.conf'
 }.freeze
 
 SPLUNK_FORWARDER_TYPES = {
-  splunkforwarder_input: 'system/local/inputs.conf',
-  splunkforwarder_output: 'system/local/outputs.conf',
-  splunkforwarder_props: 'system/local/props.conf',
-  splunkforwarder_transforms: 'system/local/transforms.conf',
-  splunkforwarder_web: 'system/local/web.conf'
+  splunkforwarder_input: 'inputs.conf',
+  splunkforwarder_output: 'outputs.conf',
+  splunkforwarder_props: 'props.conf',
+  splunkforwarder_transforms: 'transforms.conf',
+  splunkforwarder_web: 'web.conf'
 }.freeze
 
 SPLUNK_TYPES = SPLUNK_SERVER_TYPES.merge(SPLUNK_FORWARDER_TYPES)

--- a/spec/unit/puppet/type/splunk_config_spec.rb
+++ b/spec/unit/puppet/type/splunk_config_spec.rb
@@ -20,13 +20,14 @@ describe Puppet::Type.type(:splunk_config) do
     #
     SPLUNK_TYPES.each do |type, file_name|
       if SPLUNK_SERVER_TYPES.key?(type)
-        file_path = File.join('/opt/splunk/etc', file_name)
+        file_path = File.join('/opt/splunk/etc/system/local', file_name)
       elsif SPLUNK_FORWARDER_TYPES.key?(type)
-        file_path = File.join('/opt/splunkforwarder/etc', file_name)
+        file_path = File.join('/opt/splunkforwarder/etc/system/local', file_name)
       end
 
       it "should configure the #{type} type with file path #{file_path}" do
-        provider = Puppet::Type.type(type).provider(:ini_setting)
+        resource = Puppet::Type.type(type).new(name: 'foo', setting: 'foo', section: 'foo')
+        provider = Puppet::Type.type(type).provider(:ini_setting).new(resource)
         expect(provider.file_path).to eq(file_path)
       end
     end


### PR DESCRIPTION
Add a new resource parameter that allows redirection of settings into
contexts other than system/local. In prarticular this allows to
customize (and even create) apps with context =>
"apps/<app>/{default,local}". Incidentally this centralises redundant
occurences of system/local as the parameter default.
