### PR TITLE
Allow splunk server services to be overridden

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,7 @@ class splunk (
   $package_source       = $splunk::params::server_pkg_src,
   $package_name         = $splunk::params::server_pkg_name,
   $package_ensure       = $splunk::params::server_pkg_ensure,
+  $server_service       = $splunk::params::server_service,
   $logging_port         = $splunk::params::logging_port,
   $splunkd_port         = $splunk::params::splunkd_port,
   $splunk_user          = $splunk::params::splunk_user,
@@ -65,7 +66,7 @@ class splunk (
   $purge_web            = false,
 ) inherits splunk::params {
 
-  $virtual_service = $splunk::params::server_service
+  $virtual_service = $server_service
   $staging_subdir  = $splunk::params::staging_subdir
 
   $path_delimiter  = $splunk::params::path_delimiter

--- a/manifests/platform/posix.pp
+++ b/manifests/platform/posix.pp
@@ -17,6 +17,7 @@
 class splunk::platform::posix (
   $splunkd_port = $splunk::splunkd_port,
   $splunk_user = $splunk::params::splunk_user,
+  $server_service = $splunk::server_service,
 ) inherits splunk::virtual {
 
   include ::splunk::params
@@ -62,21 +63,26 @@ class splunk::platform::posix (
   # Modify virtual service definitions specific to the Linux platform. These
   # are virtual resources declared in the splunk::virtual class, which we
   # inherit.
-  Service['splunkd'] {
-    provider => 'base',
-    restart  => '/opt/splunk/bin/splunk restart splunkd',
-    start    => '/opt/splunk/bin/splunk start splunkd',
-    stop     => '/opt/splunk/bin/splunk stop splunkd',
-    pattern  => "splunkd -p ${splunkd_port} (restart|start)",
-    require  => Service['splunk'],
+  if 'splunkd' in $server_service {
+    Service['splunkd'] {
+      provider => 'base',
+      restart  => '/opt/splunk/bin/splunk restart splunkd',
+      start    => '/opt/splunk/bin/splunk start splunkd',
+      stop     => '/opt/splunk/bin/splunk stop splunkd',
+      pattern  => "splunkd -p ${splunkd_port} (restart|start)",
+      require  => Service['splunk'],
+    }
   }
-  Service['splunkweb'] {
-    provider => 'base',
-    restart  => '/opt/splunk/bin/splunk restart splunkweb',
-    start    => '/opt/splunk/bin/splunk start splunkweb',
-    stop     => '/opt/splunk/bin/splunk stop splunkweb',
-    pattern  => 'python -O /opt/splunk/lib/python.*/splunk/.*/root.py.*',
-    require  => Service['splunk'],
+  if 'splunkweb' in $server_service {
+    Service['splunkweb'] {
+      provider => 'base',
+      restart  => '/opt/splunk/bin/splunk restart splunkweb',
+      start    => '/opt/splunk/bin/splunk start splunkweb',
+      stop     => '/opt/splunk/bin/splunk stop splunkweb',
+      pattern  => 'python -O /opt/splunk/lib/python.*/splunk/.*/root.py.*',
+      require  => Service['splunk'],
+    }
   }
+
 
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->

Really useful to set `server_service => 'splunk'` since all the other services are started/stopped by the splunk init.d script.