### PR TITLE
splunk_config: Only load other splunk types

### DIFF
--- a/lib/puppet/type/splunk_config.rb
+++ b/lib/puppet/type/splunk_config.rb
@@ -1,5 +1,5 @@
 # Require all of our types so the class names are resolvable for purging
-Dir[File.dirname(__FILE__) + '/*.rb'].each do |file|
+Dir[File.dirname(__FILE__) + '/splunk*.rb'].each do |file|
   require file unless file == __FILE__
 end
 


### PR DESCRIPTION
The `splunk_config` type needs to load the other `splunk*` types for
purging.  It did this by requiring all of the other ruby files in the
same directory, which, on the client side, includes types from other
modules.  This resulted in type redefinition warnings during the agent
run, and even failures in cases where the other types included libraries
that were not present on the system:

```
Info: Redefining anchor in Puppet::Type
Info: Redefining file_line in Puppet::Type
Info: Redefining firewall in Puppet::Type
Info: Redefining firewallchain in Puppet::Type
Info: Redefining ini_setting in Puppet::Type
Error: Could not autoload puppet/provider/make_server_update/ruby: cannot load such file -- net/http/post/multipart
Error: Could not autoload puppet/type/splunk_config: Could not autoload puppet/provider/make_server_update/ruby
```

This changes the `splunk_config` type to only load other type source
files that start with 'splunk'.  Even better still would be to only load
an explicit list of types source files rather than using a glob, but
I'll leave that choice to the module maintainer.

Closes #86 

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
