### PR TITLE
types: Fix purging when section contains '//'

### DIFF
--- a/lib/puppet_x/puppetlabs/splunk/type.rb
+++ b/lib/puppet_x/puppetlabs/splunk/type.rb
@@ -7,9 +7,14 @@ module PuppetX
 
           type.define_singleton_method(:title_patterns) do
             [
-              [%r{^([^\/]*)$},   [[:section]]],
-              [%r{^(.*\/\/.*)$}, [[:section]]],
-              [%r{^(.*)\/(.*)$},
+              [%r{^([^\/]*)$}, [[:section]]],   # matches section titles without slashes, like 'tcpout:indexers'
+              [%r{^(.*\/\/.*)\/(.*)$},          # matches section titles containing '//' and a setting,
+               [                                # like: 'monitor:///var/log/messages/index'
+                 [:section, ->(x) { x }],       # where 'monitor:///var/log/messages' is the section
+                 [:setting, ->(x) { x }]        # and 'index' is the setting.
+               ]],
+              [%r{^(.*\/\/.*)$}, [[:section]]], # matches section titles containing '//', like 'tcp://127.0.0.1:19500'
+              [%r{^(.*)\/(.*)$},                # matches plain 'section/setting' titles, like: 'tcpout:indexers/server'
                [
                  [:section, ->(x) { x }],
                  [:setting, ->(x) { x }]

--- a/spec/unit/puppet/type/splunk_types_spec.rb
+++ b/spec/unit/puppet/type/splunk_types_spec.rb
@@ -41,9 +41,19 @@ SPLUNK_TYPES.each do |type, file_name|
         expect(type[:setting]).to eq('bar')
       end
 
-      it 'does not try and split URLs' do
+      it 'does not try and split simple URLs' do
         type = described_class.new(title: 'http://foo')
         expect(type[:section]).to eq('http://foo')
+      end
+
+      it 'splits more complicated URL-like patterns' do
+        type = described_class.new(title: 'monitor:///var/log/foo/index')
+        expect(type[:section]).to eq('monitor:///var/log/foo')
+      end
+
+      it 'splits more complicated URL-like patterns' do
+        type = described_class.new(title: 'monitor:///var/log/foo/index')
+        expect(type[:setting]).to eq('index')
       end
 
       it 'ignores title when section is declared' do


### PR DESCRIPTION
A change made in 0fe96f7 to support section headings of the form:

```
foo://bar
```

broke purging, where the underlying inifile type generates resources
with titles like:

```
section/setting
```

When a resource is generated with a title 'foo://bar/setting', the
setting name is not parsed.  This is the case with inputs which often
take on the form:

```
[monitor:///var/log/messages]
setting1 = value1
setting2 = value2
```

The result is an error message: "Error:
/Stage[main]/Splunk::Params/Splunk_config[splunk]: Failed to generate
additional resources using 'generate': Got nil value for setting."  See:
issue #69.

This change looks for additional slashes beyond the '://' and will
parse out the following string as the setting name.

This is not very satisfying because it could break a theoretical section
name containing extra slashes, but I have not come across that before,
and the `[monitor:///../../../]` case is **very** common.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
