### PR TITLE
Set `forwarder_install_options` to be `undef` for OS other than Windows.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -107,6 +107,7 @@ class splunk::params (
       $server_src_subdir    = 'splunk/linux'
       $server_service       = [ 'splunk', 'splunkd', 'splunkweb' ]
       $server_confdir       = "${server_dir}/etc"
+      $forwarder_install_options = undef
     }
     'SunOS': {
       $path_delimiter       = '/'
@@ -118,6 +119,7 @@ class splunk::params (
       $server_src_subdir    = 'splunk/solaris'
       $server_service       = [ 'splunk', 'splunkd', 'splunkweb' ]
       $server_confdir       = "${server_dir}/etc"
+      $forwarder_install_options = undef
     }
     'Windows': {
       $path_delimiter       = '\\'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
