### PR TITLE
This commit sets the splunk_user for Windows to 'administrator'

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -90,9 +90,11 @@ class splunk::params (
   if $::osfamily == 'Windows' {
     $forwarder_dir = pick($forwarder_installdir, 'C:\\Program Files\\SplunkUniversalForwarder')
     $server_dir    = pick($server_installdir, 'C:/Program Files/Splunk')
+    $splunk_user   = 'Administrator'
   } else {
     $forwarder_dir = pick($forwarder_installdir, '/opt/splunkforwarder')
     $server_dir    = pick($server_installdir, '/opt/splunk')
+    $splunk_user   = 'root'
   }
 
   # Settings common to a kernel
@@ -238,7 +240,6 @@ class splunk::params (
   $create_password   = true
 
   $forwarder_pkg_ensure = 'installed'
-  $splunk_user = 'root'
 
   # A meta resource so providers know where splunk is installed:
   splunk_config { 'splunk':


### PR DESCRIPTION
There was only one 'default' which was 'root', but this user is
non-existent on Windows.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
