### PR TITLE
This commit adds the pkg_provider 'chocolatey' to the module

### DIFF
--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -72,7 +72,7 @@ class splunk::forwarder (
 
   $path_delimiter  = $splunk::params::path_delimiter
   #no need for staging the source if we have yum or apt
-  if $pkg_provider != undef and $pkg_provider != 'yum' and  $pkg_provider != 'apt' {
+  if $pkg_provider != undef and $pkg_provider != 'yum' and $pkg_provider != 'apt' and $pkg_provider != 'chocolatey' {
     include ::staging
 
     $src_pkg_filename = staging_parse($package_source)
@@ -86,10 +86,16 @@ class splunk::forwarder (
     }
   }
 
+  Package  {
+    source          => $pkg_provider ? {
+      'chocolatey' => undef,
+      default      => pick($staged_package, $package_source),
+    },
+  }
+
   package { $package_name:
     ensure          => $package_ensure,
     provider        => $pkg_provider,
-    source          => pick($staged_package, $package_source),
     before          => Service[$virtual_service],
     install_options => $install_options,
     tag             => 'splunk_forwarder',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,7 +72,7 @@ class splunk (
 
   $path_delimiter  = $splunk::params::path_delimiter
 
-  if $pkg_provider != undef and $pkg_provider != 'yum' and  $pkg_provider != 'apt' {
+  if $pkg_provider != undef and $pkg_provider != 'yum' and $pkg_provider != 'apt' and $pkg_provider != 'chocolatey' {
     include ::staging
 
     $src_pkg_filename = staging_parse($package_source)
@@ -87,10 +87,16 @@ class splunk (
     }
   }
 
+  Package {
+    source   => $pkg_provider ? {
+      'chocolatey' => undef,
+      default      => pick($staged_package, $package_source),
+    },
+  }
+
   package { $package_name:
     ensure   => $package_ensure,
     provider => $pkg_provider,
-    source   => pick($staged_package, $package_source),
     before   => Service[$virtual_service],
     tag      => 'splunk_server',
   }


### PR DESCRIPTION
When using 'chocolatey' as pkg_provider it is not needed to
include :staging, this is excluded in the init.pp and forwarder.pp

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
