### PR TITLE
Allow for installing packages from UNC paths on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,8 @@ default TCP output and input.
 The source URL for the splunk installation media (typically an RPM, MSI,
 etc). If a $src_root parameter is set in splunk::params, this will be
 automatically supplied. Otherwise it is required. The URL can be of any
-protocol supported by the nanliu/staging module.
+protocol supported by the nanliu/staging module. On Windows, this can be
+a UNC path to the MSI.
 
 #### `package_name`
 
@@ -351,7 +352,8 @@ longer managed by the splunk_web type. Default to false.
 The source URL for the splunk installation media (typically an RPM, MSI,
 etc). If a $src_root parameter is set in splunk::params, this will be
 automatically supplied. Otherwise it is required. The URL can be of any
-protocol supported by the nanliu/staging module.
+protocol supported by the nanliu/staging module. On Windows, this can be
+a UNC path to the MSI.
 
 #### `package_name`
 

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -75,20 +75,21 @@ class splunk::forwarder (
   if $pkg_provider != undef and $pkg_provider != 'yum' and  $pkg_provider != 'apt' {
     include ::staging
 
-    $staged_package  = staging_parse($package_source)
-    $pkg_path_parts  = [$staging::path, $staging_subdir, $staged_package]
-    $pkg_source      = join($pkg_path_parts, $path_delimiter)
+    $src_pkg_filename = staging_parse($package_source)
+    $pkg_path_parts   = [$staging::path, $staging_subdir, $src_pkg_filename]
+    $staged_package   = join($pkg_path_parts, $path_delimiter)
 
-    staging::file { $staged_package:
+    staging::file { $src_pkg_filename:
       source => $package_source,
       subdir => $staging_subdir,
       before => Package[$package_name],
     }
   }
+
   package { $package_name:
     ensure          => $package_ensure,
     provider        => $pkg_provider,
-    source          => pick($pkg_source, $package_source),
+    source          => pick($staged_package, $package_source),
     before          => Service[$virtual_service],
     install_options => $install_options,
     tag             => 'splunk_forwarder',

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -12,7 +12,8 @@
 #   The source URL for the splunk installation media (typically an RPM, MSI,
 #   etc). If a $src_root parameter is set in splunk::params, this will be
 #   automatically supplied. Otherwise it is required. The URL can be of any
-#   protocol supported by the nanliu/staging module.
+#   protocol supported by the nanliu/staging module. On Windows, this can
+#   be a UNC path to the MSI.
 #
 # [*package_name*]
 #   The name of the package(s) as they will exist or be detected on the host.
@@ -87,7 +88,7 @@ class splunk::forwarder (
   package { $package_name:
     ensure          => $package_ensure,
     provider        => $pkg_provider,
-    source          => $pkg_source,
+    source          => pick($pkg_source, $package_source),
     before          => Service[$virtual_service],
     install_options => $install_options,
     tag             => 'splunk_forwarder',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,8 @@
 #   The source URL for the splunk installation media (typically an RPM, MSI,
 #   etc). If a $src_root parameter is set in splunk::params, this will be
 #   automatically supplied. Otherwise it is required. The URL can be of any
-#   protocol supported by the nanliu/staging module.
+#   protocol supported by the nanliu/staging module. On Windows, this can
+#   be a UNC path to the MSI.
 #
 # [*package_name*]
 #   The name of the package(s) as they will exist or be detected on the host.
@@ -89,7 +90,7 @@ class splunk (
   package { $package_name:
     ensure   => $package_ensure,
     provider => $pkg_provider,
-    source   => $pkg_source,
+    source   => pick($pkg_source, $package_source),
     before   => Service[$virtual_service],
     tag      => 'splunk_server',
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,12 +75,12 @@ class splunk (
   if $pkg_provider != undef and $pkg_provider != 'yum' and  $pkg_provider != 'apt' {
     include ::staging
 
-    $staged_package  = staging_parse($package_source)
-    $pkg_path_parts  = [$staging::path, $staging_subdir, $staged_package]
-    $pkg_source      = join($pkg_path_parts, $path_delimiter)
+    $src_pkg_filename = staging_parse($package_source)
+    $pkg_path_parts   = [$staging::path, $staging_subdir, $src_pkg_filename]
+    $staged_package   = join($pkg_path_parts, $path_delimiter)
 
     #no need for staging the source if we have yum or apt
-    staging::file { $staged_package:
+    staging::file { $src_pkg_filename:
       source => $package_source,
       subdir => $staging_subdir,
       before => Package[$package_name],
@@ -90,7 +90,7 @@ class splunk (
   package { $package_name:
     ensure   => $package_ensure,
     provider => $pkg_provider,
-    source   => pick($pkg_source, $package_source),
+    source   => pick($staged_package, $package_source),
     before   => Service[$virtual_service],
     tag      => 'splunk_server',
   }


### PR DESCRIPTION
This PR incorporates commits that ultimately allow Windows agents to install packages from UNC paths.

Prior to this, if setting `$package_source` to a UNC path on Windows, the `package` resource wouldn't ever use the value of `$package_source` as it's source. The reason for that is because a UNC path doesn't need to be staged with `staging::file` thus the `$pkg_source` variable was never set.

While I was fixing that problem, I also cleaned up the variable names in the `staging::file` steps to make their intent more clear. 