### PR TITLE
Fix .conf file modes for Windows forwarders

### DIFF
--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -156,7 +156,10 @@ class splunk::forwarder (
   File {
     owner => $splunk_user,
     group => $splunk_user,
-    mode => '0644',
+    mode  => $facts['kernel'] ? {
+      'windows' => undef,
+      default   => '0644',
+    }
   }
 
   file { "${forwarder_confdir}/system/local/inputs.conf":


### PR DESCRIPTION
Prior to this, the file mode for `inputs.conf`, `outputs.conf`, and `web.conf`
would change from `0664` to `0644` on every Puppet run.

On Windows, we don't want to set the file mode for these files as
handling the permissions on these would [best be left](https://docs.puppet.com/puppet/4.10/resources_file_windows.html#consider-using-the-acl-resource-type-instead) for the
[puppetlabs/acl module](https://forge.puppetlabs.com/puppetlabs/acl).