### PR TITLE
Added splunkforwarder_server and splunkforwarder_limits providers/types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ the inputs.conf file and refresh the service.
 * `splunkforwarder_props`: Used to manage ini settings in [props.conf][props.conf-docs]
 * `splunkforwarder_transforms`: Used to manage ini settings in [transforms.conf][transforms.conf-docs]
 * `splunkforwarder_web`: Used to manage ini settings in [web.conf][web.conf-docs]
+* `splunkforwarder_limits`: Used to manage ini settings in [limits.conf][limits.conf-docs]
+* `splunkforwarder_server`: Used to manage ini settings in [server.conf][server.conf-docs]
 
 All of the above types use `puppetlabs/ini_file` as a parent and are declared in
 an identical way, and accept the following parameters:

--- a/lib/puppet/provider/splunkforwarder_limits/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_limits/ini_setting.rb
@@ -1,0 +1,8 @@
+Puppet::Type.type(:splunkforwarder_limits).provide(
+  :ini_setting,
+  parent: Puppet::Type.type(:ini_setting).provider(:splunk)
+) do
+  def self.file_name
+    'limits.conf'
+  end
+end

--- a/lib/puppet/provider/splunkforwarder_server/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_server/ini_setting.rb
@@ -1,0 +1,8 @@
+Puppet::Type.type(:splunkforwarder_server).provide(
+  :ini_setting,
+  parent: Puppet::Type.type(:ini_setting).provider(:splunk)
+) do
+  def self.file_name
+    'server.conf'
+  end
+end

--- a/lib/puppet/type/splunkforwarder_limits.rb
+++ b/lib/puppet/type/splunkforwarder_limits.rb
@@ -1,0 +1,6 @@
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
+
+Puppet::Type.newtype(:splunkforwarder_limits) do
+  @doc = 'Manage splunkforwarder limit settings in limits.conf'
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
+end

--- a/lib/puppet/type/splunkforwarder_server.rb
+++ b/lib/puppet/type/splunkforwarder_server.rb
@@ -1,0 +1,6 @@
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
+
+Puppet::Type.newtype(:splunkforwarder_server) do
+  @doc = 'Manage splunkforwarder server settings in server.conf'
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
+end

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -189,12 +189,12 @@ class splunk::forwarder (
 
   file { "${forwarder_confdir}/system/local/limits.conf":
     ensure => file,
-    tag    => 'splunk_forwader',
+    tag    => 'splunk_forwarder',
   }
 
   file { "${forwarder_confdir}/system/local/server.conf":
     ensure => file,
-    tag    => 'splunk_forwader',
+    tag    => 'splunk_forwarder',
   }
 
   # Validate: if both Splunk and Splunk Universal Forwarder are installed on

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -160,6 +160,8 @@ class splunk::forwarder (
   Package[$package_name] -> Splunkforwarder_props<||>      ~> Service[$virtual_service]
   Package[$package_name] -> Splunkforwarder_transforms<||> ~> Service[$virtual_service]
   Package[$package_name] -> Splunkforwarder_web<||>        ~> Service[$virtual_service]
+  Package[$package_name] -> Splunkforwarder_limits<||>     ~> Service[$virtual_service]
+  Package[$package_name] -> Splunkforwarder_server<||>     ~> Service[$virtual_service]
 
   File {
     owner => $splunk_user,
@@ -183,6 +185,16 @@ class splunk::forwarder (
   file { "${forwarder_confdir}/system/local/web.conf":
     ensure => file,
     tag    => 'splunk_forwarder',
+  }
+
+  file { "${forwarder_confdir}/system/local/limits.conf":
+    ensure => file,
+    tag    => 'splunk_forwader',
+  }
+
+  file { "${forwarder_confdir}/system/local/server.conf":
+    ensure => file,
+    tag    => 'splunk_forwader',
   }
 
   # Validate: if both Splunk and Splunk Universal Forwarder are installed on


### PR DESCRIPTION
This PR adds functionality to allow server.conf and limits.conf to be managed by puppet code. For example one of our use cases:

```
splunkforwarder_limits { 'thruput/maxKBps':
  value => $maxkbps,
  tag   => 'splunk_forwarder'
}
splunkforwarder_server { 'httpServer/disableDefaultPort':
  value => 'true',
  tag   => 'splunk_forwarder'
}
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
