### PR TITLE
Fixing global varaible reference

### DIFF
--- a/manifests/platform/posix.pp
+++ b/manifests/platform/posix.pp
@@ -17,7 +17,7 @@
 class splunk::platform::posix (
   $splunkd_port = $splunk::splunkd_port,
   $splunk_user = $splunk::params::splunk_user,
-  $server_service = $splunk::server_service,
+  $server_service = $splunk::params::server_service,
 ) inherits splunk::virtual {
 
   include ::splunk::params


### PR DESCRIPTION
It looks like whoever added the server_service parameter to the posix class left of the ::params::.  This is Preventing others from writing unit tests against this.


@treydock can you verify this was a mistake/typo?