### PR TITLE
SplunkForwarder has no concept of a server_service. 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -146,7 +146,13 @@ class splunk (
   # there is non-generic configuration that needs to be declared in addition
   # to the agnostic resources declared here.
   case $::kernel {
-    'Linux': { include ::splunk::platform::posix   }
+    'Linux': {
+      class { '::splunk::platform::posix':
+        splunkd_port   => $splunkd_port,
+        splunk_user    => $splunk_user,
+        server_service => $server_service,
+      }
+    }
     'SunOS': { include ::splunk::platform::solaris }
     default: { } # no special configuration needed
   }

--- a/manifests/platform/posix.pp
+++ b/manifests/platform/posix.pp
@@ -17,7 +17,7 @@
 class splunk::platform::posix (
   $splunkd_port = $splunk::splunkd_port,
   $splunk_user = $splunk::params::splunk_user,
-  $server_service = $splunk::server_service,
+  $server_service = undef,
 ) inherits splunk::virtual {
 
   include ::splunk::params

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe 'splunk::forwarder' do
-  on_supported_os.each do |os, os_facts |
+  on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-     
+
       context 'with defaults' do
-        if (os == 'solaris-11-i86pc')
+        if os == 'solaris-11-i86pc'
           pending
         else
           it { is_expected.to compile.with_all_deps }

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'splunk::forwarder' do
+  on_supported_os.each do |os, os_facts |
+    context "on #{os}" do
+      let(:facts) { os_facts }
+     
+      context 'with defaults' do
+        if (os == 'solaris-11-i86pc')
+          pending
+        else
+          it { is_expected.to compile.with_all_deps }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
when setting up a splunk forwarder on a posix based system you get a warning because the the default parameter for the splunk::platform::posix class is set to $splunk::server_service which doesn't exist when you create a forwarder.  It doesn't exist because it doesn't make sense for a forwarder.  While there should be more cleanup this is a simple non-breaking change to fix the annoying warning.  A bigger refactor would be required to get this done correctly.

#119 