### PR TITLE
Add serverclass type

### DIFF
--- a/lib/puppet/provider/splunk_serverclass/ini_setting.rb
+++ b/lib/puppet/provider/splunk_serverclass/ini_setting.rb
@@ -1,0 +1,8 @@
+Puppet::Type.type(:splunk_serverclass).provide(
+  :ini_setting,
+  parent: Puppet::Type.type(:ini_setting).provider(:splunk)
+) do
+  def self.file_name
+    'serverclass.conf'
+  end
+end

--- a/lib/puppet/type/splunk_config.rb
+++ b/lib/puppet/type/splunk_config.rb
@@ -33,6 +33,7 @@ Puppet::Type.newtype(:splunk_config) do
     :purge_limits,
     :purge_props,
     :purge_server,
+    :purge_serverclass,
     :purge_transforms,
     :purge_web,
     :purge_uiprefs,
@@ -69,6 +70,7 @@ Puppet::Type.newtype(:splunk_config) do
       Puppet::Type::Splunk_indexes                   => self[:purge_indexes],
       Puppet::Type::Splunk_props                     => self[:purge_props],
       Puppet::Type::Splunk_server                    => self[:purge_server],
+      Puppet::Type::Splunk_serverclass               => self[:purge_serverclass],
       Puppet::Type::Splunk_transforms                => self[:purge_transforms],
       Puppet::Type::Splunk_web                       => self[:purge_web],
       Puppet::Type::Splunk_uiprefs                   => self[:purge_uiprefs],
@@ -99,6 +101,7 @@ Puppet::Type.newtype(:splunk_config) do
       :splunk_output,
       :splunk_props,
       :splunk_server,
+      :splunk_serverclass,
       :splunk_transforms,
       :splunk_web,
       :splunk_uiprefs

--- a/lib/puppet/type/splunk_serverclass.rb
+++ b/lib/puppet/type/splunk_serverclass.rb
@@ -1,0 +1,6 @@
+require File.join(File.dirname(__FILE__), '..', '..', 'puppet_x/puppetlabs/splunk/type')
+
+Puppet::Type.newtype(:splunk_serverclass) do
+  @doc = 'Manage splunk serverclass entries in serverclass.conf'
+  PuppetX::Puppetlabs::Splunk::Type.clone_type(self)
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,7 @@ class splunk (
   $purge_outputs          = false,
   $purge_props            = false,
   $purge_server           = false,
+  $purge_serverclass      = false,
   $purge_transforms       = false,
   $purge_uiprefs          = false,
   $purge_web              = false,
@@ -142,6 +143,7 @@ class splunk (
     purge_outputs          => $purge_outputs,
     purge_props            => $purge_props,
     purge_server           => $purge_server,
+    purge_serverclass      => $purge_serverclass,
     purge_transforms       => $purge_transforms,
     purge_uiprefs          => $purge_uiprefs,
     purge_web              => $purge_web
@@ -231,6 +233,11 @@ class splunk (
 
   Package[$package_name]
   -> File                   <| tag   == 'splunk_server'  |>
+  -> Splunk_serverclass     <| tag   == 'splunk_server'  |>
+  ~> Service[$virtual_service]
+
+  Package[$package_name]
+  -> File                   <| tag   == 'splunk_server'  |>
   -> Splunk_transforms      <| tag   == 'splunk_server'  |>
   ~> Service[$virtual_service]
 
@@ -301,6 +308,11 @@ class splunk (
   }
 
   file { '/opt/splunk/etc/system/local/server.conf':
+    ensure => file,
+    tag    => 'splunk_server',
+  }
+
+  file { '/opt/splunk/etc/system/local/serverclass.conf':
     ensure => file,
     tag    => 'splunk_server',
   }

--- a/spec/acceptance/splunk_spec.rb
+++ b/spec/acceptance/splunk_spec.rb
@@ -21,5 +21,15 @@ describe 'splunk class' do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end
+
+    SPLUNK_TYPES.select { |type| SPLUNK_SERVER_TYPES.key?(type) }.each do |_type, file_name|
+      conf_file_path = File.join('/opt/splunk/etc/system/local', file_name)
+      describe file(conf_file_path) do
+        it { is_expected.to be_file }
+        it { is_expected.to be_mode 600 }
+        it { is_expected.to be_owned_by 'root' }
+        it { is_expected.to be_grouped_into 'root' }
+      end
+    end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,6 +2,7 @@ require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
+require 'splunk_data.rb'
 
 run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
 install_module

--- a/spec/splunk_data.rb
+++ b/spec/splunk_data.rb
@@ -11,6 +11,7 @@ SPLUNK_SERVER_TYPES = {
   splunk_output: 'outputs.conf',
   splunk_props: 'props.conf',
   splunk_server: 'server.conf',
+  splunk_serverclass: 'serverclass.conf',
   splunk_transforms: 'transforms.conf',
   splunk_uiprefs: 'ui-prefs.conf',
   splunk_web: 'web.conf'


### PR DESCRIPTION
Added a new type that allows the creationg of deployment server 'server classes'. 

- [x] Added Unit tests for it
- [x] Added acceptance tests
- [x] Went ahead and added the same acceptance tests for all other configuration files on a splunk server
closes #147 