### PR TITLE
[BREAKING CHANGE] Updated http download structure

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,6 +1,13 @@
 ---
 .travis.yml:
   secure: "RrAmWtM6eTjZZzD954AIgR179Pqp14lzHhd/C9cpKbTPynLncuim08CEvjmq+7pgAy9XDg1d02x3udfZt4btR1sBdyNRpNN3yUhWptmGU61HRJdiZq+nSLQkIYsqXanhk+O3NndFojO58WRD01dkWEc6HRHjlivuYNxDXmMkg9k="
+  docker_sets:
+  - set: docker/centos-6
+  - set: docker/centos-7
+  - set: docker/debian-7
+  - set: docker/debian-8
+  - set: docker/ubuntu-14.04
+  - set: docker/ubuntu-16.04
 spec/spec_helper.rb:
   spec_overrides: 
   - "require 'splunk_data.rb'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,42 @@ script:
 matrix:
   fast_finish: true
   include:
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-6 CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7 CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/debian-7 CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/debian-8 CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04 CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-16.04 CHECK=beaker
+    services: docker
+    sudo: required
   - rvm: 2.1.9
     bundler_args: --without system_tests development
     env: PUPPET_VERSION="~> 4.0" CHECK=test

--- a/README.md
+++ b/README.md
@@ -70,32 +70,40 @@ The files must be placed according to directory structure example given below.
 
 The expected directory structure is:
 
-      `-- files
-          |-- splunk
-          |   `-- $platform
-          |       `-- splunk-${version}-${build}-${additl}
-          `-- universalforwarder
-              `-- $platform
-                  `-- splunkforwarder-${version}-${build}-${additl}
+     $root_url/
+     └── products/
+         ├── universalforwarder/
+         │   └── releases/
+         |       └── $version/
+         |           └── $platform/
+         |               └── splunkforwarder-${version}-${build}-${additl}
+         └── splunk/
+             └── releases/
+                 └── $version/
+                     └── $platform/
+                         └── splunk-${version}-${build}-${additl}
 
 A semi-populated example files directory might then contain:
 
-      `-- files
-          |-- splunk
-          |   `-- linux
-          |       |-- splunk-6.3.3-f44afce176d0-linux-2.6-amd64.deb
-          |       |-- splunk-6.3.3-f44afce176d0-linux-2.6-intel.deb
-          |       `-- splunk-6.3.3-f44afce176d0-linux-2.6-x86_64.rpm
-          `-- universalforwarder
-              |-- linux
-              |   |-- splunkforwarder-6.3.3-f44afce176d0-linux-2.6-amd64.deb
-              |   |-- splunkforwarder-6.3.3-f44afce176d0-linux-2.6-intel.deb
-              |   `-- splunkforwarder-6.3.3-f44afce176d0-linux-2.6-x86_64.rpm
-              |-- solaris
-              |   `-- splunkforwarder-6.3.3-f44afce176d0-solaris-9-intel.pkg
-              `-- windows
-                  |-- splunkforwarder-6.3.3-f44afce176d0-x64-release.msi
-                  `-- splunkforwarder-6.3.3-f44afce176d0-x86-release.msi
+    $root_url/
+    └── products/
+        ├── universalforwarder/
+        │   └── releases/
+        |       └── 7.0.0/
+        |           ├── linux/
+        |           |   ├── splunkforwarder-7.0.0-c8a78efdd40f-linux-2.6-amd64.deb
+        |           |   ├── splunkforwarder-7.0.0-c8a78efdd40f-linux-2.6-intel.deb
+        |           |   └── splunkforwarder-7.0.0-c8a78efdd40f-linux-2.6-x86_64.rpm
+        |           ├── solaris/
+        |           └── windows/
+        |               └── splunkforwarder-7.0.0-c8a78efdd40f-x64-release.msi
+        └── splunk/
+            └── releases/
+                └── 7.0.0/
+                    └── linux/
+                        ├── splunk-7.0.0-c8a78efdd40f-linux-2.6-amd64.deb
+                        ├── splunk-7.0.0-c8a78efdd40f-linux-2.6-intel.deb
+                        └── splunk-7.0.0-c8a78efdd40f-linux-2.6-x86_64.rpm
 
 Second, you will need to supply the `splunk::params` class with three critical
 pieces of information.

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -170,7 +170,7 @@ class splunk::forwarder (
     group => $splunk_user,
     mode  => $facts['kernel'] ? {
       'windows' => undef,
-      default   => '0644',
+      default   => '0600',
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,6 +103,21 @@ class splunk (
     tag      => 'splunk_server',
   }
 
+  if $facts['virtual'] == 'docker' {
+    ini_setting { 'OPTIMISTIC_ABOUT_FILE_LOCKING':
+      ensure  => present,
+      section => '',
+      setting => 'OPTIMISTIC_ABOUT_FILE_LOCKING',
+      value   => '1',
+      path    => '/opt/splunk/etc/splunk-launch.conf',
+    }
+
+    Package[$package_name]
+    -> Ini_setting['OPTIMISTIC_ABOUT_FILE_LOCKING']
+    -> Exec <| tag   == 'splunk_server'  |>
+  }
+
+
   splunk_input { 'default_host':
     section => 'default',
     setting => 'host',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,32 +33,43 @@
 #   the puppet/archive module supports. This includes both puppet:// and
 #   http://.  The expected directory structure is:
 #
-#     `-- $root_url
-#         |-- splunk
-#         |   `-- $platform
-#         |       `-- splunk-${version}-${build}-${additl}
-#         `-- universalforwarder
-#             `-- $platform
-#                 `-- splunkforwarder-${version}-${build}-${additl}
+#
+#     $root_url/
+#     └── products/
+#         ├── universalforwarder/
+#         │   └── releases/
+#         |       └── $version/
+#         |           └── $platform/
+#         |               └── splunkforwarder-${version}-${build}-${additl}
+#         └── splunk/
+#             └── releases/
+#                 └── $version/
+#                     └── $platform/
+#                         └── splunk-${version}-${build}-${additl}
+#
 #
 #   A semi-populated example src_root then contain:
 #
-#     `-- $root_url
-#         |-- splunk
-#         |   `-- linux
-#         |       |-- splunk-4.3.2-123586-linux-2.6-amd64.deb
-#         |       |-- splunk-4.3.2-123586-linux-2.6-intel.deb
-#         |       `-- splunk-4.3.2-123586-linux-2.6-x86_64.rpm
-#         `-- universalforwarder
-#             |-- linux
-#             |   |-- splunkforwarder-4.3.2-123586-linux-2.6-amd64.deb
-#             |   |-- splunkforwarder-4.3.2-123586-linux-2.6-intel.deb
-#             |   `-- splunkforwarder-4.3.2-123586-linux-2.6-x86_64.rpm
-#             |-- solaris
-#             |   `-- splunkforwarder-4.3.2-123586-solaris-10-intel.pkg
-#             `-- windows
-#                 |-- splunkforwarder-4.3.2-123586-x64-release.msi
-#                 `-- splunkforwarder-4.3.2-123586-x86-release.msi
+#     $root_url/
+#     └── products/
+#         ├── universalforwarder/
+#         │   └── releases/
+#         |       └── 7.0.0/
+#         |           ├── linux/
+#         |           |   ├── splunkforwarder-7.0.0-c8a78efdd40f-linux-2.6-amd64.deb
+#         |           |   ├── splunkforwarder-7.0.0-c8a78efdd40f-linux-2.6-intel.deb
+#         |           |   └── splunkforwarder-7.0.0-c8a78efdd40f-linux-2.6-x86_64.rpm
+#         |           ├── solaris/
+#         |           └── windows/
+#         |               └── splunkforwarder-7.0.0-c8a78efdd40f-x64-release.msi
+#         └── splunk/
+#             └── releases/
+#                 └── 7.0.0/
+#                     └── linux/
+#                         ├── splunk-7.0.0-c8a78efdd40f-linux-2.6-amd64.deb
+#                         ├── splunk-7.0.0-c8a78efdd40f-linux-2.6-intel.deb
+#                         └── splunk-7.0.0-c8a78efdd40f-linux-2.6-x86_64.rpm
+#
 #
 # Actions:
 #
@@ -67,9 +78,9 @@
 # Requires: nothing
 #
 class splunk::params (
-  $version              = '6.3.3',
-  $build                = 'f44afce176d0',
-  $src_root             = 'puppet:///modules/splunk',
+  $version              = '7.0.0',
+  $build                = 'c8a78efdd40f',
+  $src_root             = 'https://download.splunk.com',
   $splunkd_port         = '8089',
   $logging_port         = '9997',
   $server               = 'splunk',
@@ -101,36 +112,36 @@ class splunk::params (
   case $::kernel {
     'Linux': {
       $path_delimiter       = '/'
-      $forwarder_src_subdir = 'universalforwarder/linux'
+      $forwarder_src_subdir = 'linux'
       $forwarder_service    = [ 'splunk' ]
       $password_config_file = "${forwarder_dir}/etc/passwd"
       $secret_file          = "${forwarder_dir}/etc/splunk.secret"
       $forwarder_confdir    = "${forwarder_dir}/etc"
-      $server_src_subdir    = 'splunk/linux'
+      $server_src_subdir    = 'linux'
       $server_service       = [ 'splunk', 'splunkd', 'splunkweb' ]
       $server_confdir       = "${server_dir}/etc"
       $forwarder_install_options = undef
     }
     'SunOS': {
       $path_delimiter       = '/'
-      $forwarder_src_subdir = 'universalforwarder/solaris'
+      $forwarder_src_subdir = 'solaris'
       $forwarder_service    = [ 'splunk' ]
       $password_config_file = "${forwarder_dir}/etc/passwd"
       $secret_file          = "${forwarder_dir}/etc/splunk.secret"
       $forwarder_confdir    = "${forwarder_dir}/etc"
-      $server_src_subdir    = 'splunk/solaris'
+      $server_src_subdir    = 'solaris'
       $server_service       = [ 'splunk', 'splunkd', 'splunkweb' ]
       $server_confdir       = "${server_dir}/etc"
       $forwarder_install_options = undef
     }
     'Windows': {
       $path_delimiter       = '\\'
-      $forwarder_src_subdir = 'universalforwarder/windows'
+      $forwarder_src_subdir = 'windows'
       $password_config_file = 'C:/Program Files/SplunkUniversalForwarder/etc/passwd'
       $secret_file          =  'C:/Program Files/SplunkUniversalForwarder/etc/splunk.secret'
       $forwarder_service    = [ 'SplunkForwarder' ] # UNKNOWN
       $forwarder_confdir    = "${forwarder_dir}/etc"
-      $server_src_subdir    = 'splunk/windows'
+      $server_src_subdir    = 'windows'
       $server_service       = [ 'Splunkd', 'SplunkWeb' ] # UNKNOWN
       $server_confdir       = "${server_dir}/etc"
       $forwarder_install_options = [
@@ -237,8 +248,8 @@ class splunk::params (
   $server_src_pkg    = "splunk-${package_suffix}"
 
   $server_pkg_ensure = 'installed'
-  $server_pkg_src    = "${src_root}/${server_src_subdir}/${server_src_pkg}"
-  $forwarder_pkg_src = "${src_root}/${forwarder_src_subdir}/${forwarder_src_pkg}"
+  $server_pkg_src    = "${src_root}/products/splunk/releases/${version}/${server_src_subdir}/${server_src_pkg}"
+  $forwarder_pkg_src = "${src_root}/products/universalforwarder/releases/${version}/${forwarder_src_subdir}/${forwarder_src_pkg}"
   $create_password   = true
 
   $forwarder_pkg_ensure = 'installed'

--- a/spec/acceptance/splunk_forwarder_spec.rb
+++ b/spec/acceptance/splunk_forwarder_spec.rb
@@ -5,7 +5,11 @@ describe 'splunk::forwarder class' do
     # Using puppet_apply as a helper
     it 'works idempotently with no errors' do
       pp = <<-EOS
-      class { '::splunk::forwarder': }
+      class { '::splunk::params':
+      }
+      class { '::splunk::forwarder':
+        splunkd_port => 8090,
+      }
       EOS
 
       # Run it twice and test for idempotency


### PR DESCRIPTION
This module used to be able to download splunk installer from splunk directly.  Unfortunately, when splunk updates their http url paths this module didnt get updated as well.  This updates the structure of where the installers should live along with hooking up docker containers for running in travis.  **Merging this would be considered a breaking change since the folder structure where people are placing the installers at on their local file system are changing to match how splunk NOW does it**.

Summary
- Updated expected folder structure for the splunk installers
- Updated Documentation of folder structure
- Updated default download location to be https://download.splunk.com in order to help people use this module easier instead of having to manually prestage the splunk installers.
- Updated acceptance tests to pull from download.splunk.com
- Updated .sync.yml to include the docker sets that should run under travis for beaker acceptance tests
- Fixed a bug where the forwarder is not actually idempotent because of a file mode. 🐛 
- In order to get acceptance testing working in docker i had to actually get this module to work while inside a docker container for the splunk server using OPTIMISTIC_ABOUT_FILE_LOCKING ( reference: https://github.com/chef-cookbooks/chef-splunk/blob/611be81ac8e533af7a71f0b2836e8de3aa346373/.kitchen.dokken.yml#L114-L126 )