### PR TITLE
(maint) Bumping inifile dependency from > 2.0.0 to > 3.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -73,7 +73,7 @@
     },
     {
       "name": "puppetlabs-inifile",
-      "version_requirement": ">= 1.4.1 < 2.0.0"
+      "version_requirement": ">= 1.4.1 < 3.0.0"
     },
     {
       "name": "puppetlabs-concat",


### PR DESCRIPTION
**Pull Request (PR) description**
Bump dependency of the puppetlabs/inifile module to handle the newer versions without the PMT tool throwing dependency issues

**This Pull Request (PR) fixes the following issues:**
Fixes #172 

**Task list:**
- [x] Bump dependency in metadata.json file. ( .fixtures.yml is pointed to the lastest master branch so no bumping needed in here )
