### PR TITLE
Remove unsupported use of proc in title patterns

### DIFF
--- a/lib/puppet_x/puppetlabs/splunk/type.rb
+++ b/lib/puppet_x/puppetlabs/splunk/type.rb
@@ -10,14 +10,14 @@ module PuppetX
               [%r{^([^\/]*)$}, [[:section]]],   # matches section titles without slashes, like 'tcpout:indexers'
               [%r{^(.*\/\/.*)\/(.*)$},          # matches section titles containing '//' and a setting,
                [                                # like: 'monitor:///var/log/messages/index'
-                 [:section, ->(x) { x }],       # where 'monitor:///var/log/messages' is the section
-                 [:setting, ->(x) { x }]        # and 'index' is the setting.
+                 [:section],       # where 'monitor:///var/log/messages' is the section
+                 [:setting]        # and 'index' is the setting.
                ]],
               [%r{^(.*\/\/.*)$}, [[:section]]], # matches section titles containing '//', like 'tcp://127.0.0.1:19500'
               [%r{^(.*)\/(.*)$},                # matches plain 'section/setting' titles, like: 'tcpout:indexers/server'
                [
-                 [:section, ->(x) { x }],
-                 [:setting, ->(x) { x }]
+                 [:section],
+                 [:setting]
                ]]
             ]
           end


### PR DESCRIPTION
This will allow `puppet generate types` to function

Example:
```
Error: /etc/puppetlabs/code/environments/production/modules/splunk/lib/puppet/type/splunk_alert_actions.rb: title patterns that use procs are not supported.
```

https://tickets.puppetlabs.com/browse/MODULES-4505?focusedCommentId=418416&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-418416
https://github.com/treydock/puppet-module-keycloak/pull/21

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
