### PR TITLE
Windows fixes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -272,77 +272,77 @@ class splunk (
     mode => '0600',
   }
 
-  file { '/opt/splunk/etc/system/local/alert_actions.conf':
+  file { "${server_confdir}/system/local/alert_actions.conf":
     ensure => file,
     tag    => 'splunk_server',
   }
 
-  file { '/opt/splunk/etc/system/local/authentication.conf':
+  file { "${server_confdir}/system/local/authentication.conf":
     ensure => file,
     tag    => 'splunk_server',
   }
 
-  file { '/opt/splunk/etc/system/local/authorize.conf':
+  file { "${server_confdir}/system/local/authorize.conf":
     ensure => file,
     tag    => 'splunk_server',
   }
 
-  file { '/opt/splunk/etc/system/local/deploymentclient.conf':
+  file { "${server_confdir}/system/local/deploymentclient.conf":
     ensure => file,
     tag    => 'splunk_server',
   }
 
-  file { '/opt/splunk/etc/system/local/distsearch.conf':
+  file { "${server_confdir}/system/local/distsearch.conf":
     ensure => file,
     tag    => 'splunk_server',
   }
 
-  file { '/opt/splunk/etc/system/local/indexes.conf':
+  file { "${server_confdir}/system/local/indexes.conf":
     ensure => file,
     tag    => 'splunk_server',
   }
 
-  file { '/opt/splunk/etc/system/local/inputs.conf':
+  file { "${server_confdir}/system/local/inputs.conf":
     ensure => file,
     tag    => 'splunk_server',
   }
 
-  file { '/opt/splunk/etc/system/local/limits.conf':
+  file { "${server_confdir}/system/local/limits.conf":
     ensure => file,
     tag    => 'splunk_server',
   }
 
-  file { '/opt/splunk/etc/system/local/outputs.conf':
+  file { "${server_confdir}/system/local/outputs.conf":
     ensure => file,
     tag    => 'splunk_server',
   }
 
-  file { '/opt/splunk/etc/system/local/props.conf':
+  file { "${server_confdir}/system/local/props.conf":
     ensure => file,
     tag    => 'splunk_server',
   }
 
-  file { '/opt/splunk/etc/system/local/server.conf':
+  file { "${server_confdir}/system/local/server.conf":
     ensure => file,
     tag    => 'splunk_server',
   }
 
-  file { '/opt/splunk/etc/system/local/serverclass.conf':
+  file { "${server_confdir}/system/local/serverclass.conf":
     ensure => file,
     tag    => 'splunk_server',
   }
 
-  file { '/opt/splunk/etc/system/local/transforms.conf':
+  file { "${server_confdir}/system/local/transforms.conf":
     ensure => file,
     tag    => 'splunk_server',
   }
 
-  file { '/opt/splunk/etc/system/local/ui-prefs.conf':
+  file { "${server_confdir}/system/local/ui-prefs.conf":
     ensure => file,
     tag    => 'splunk_server',
   }
 
-  file { '/opt/splunk/etc/system/local/web.conf':
+  file { "${server_confdir}/system/local/web.conf":
     ensure => file,
     tag    => 'splunk_server',
   }

--- a/spec/classes/splunk_spec.rb
+++ b/spec/classes/splunk_spec.rb
@@ -3,6 +3,13 @@ require 'spec_helper'
 describe 'splunk' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
+      package_name = 'splunk'
+      service_name = 'splunk'
+      if /^windows-/ =~ os then
+        package_name = 'Splunk'
+	service_name = 'Splunkd'
+      end
+
       context "on #{os}" do
         let(:facts) do
           facts
@@ -13,8 +20,8 @@ describe 'splunk' do
 
           it { is_expected.to contain_class('splunk::params') }
 
-          it { is_expected.to contain_service('splunk') }
-          it { is_expected.to contain_package('splunk').with_ensure('installed') }
+          it { is_expected.to contain_service(service_name) }
+          it { is_expected.to contain_package(package_name).with_ensure('installed') }
         end
       end
     end


### PR DESCRIPTION
Hi,

when rebased against https://github.com/voxpupuli/puppet-splunk/pull/179 these changes fix the remaining Windows problems:

- the config file resources actually do not use the correct path on Windows and this problem is called out by the test suite
- service and package names differ on Windows


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
