### PR TITLE
Allow forwarder to fully support alternate install directories

### DIFF
--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -126,6 +126,7 @@ class splunk::forwarder (
   # the respective config files.
 
   Splunk_config['splunk'] {
+    forwarder_confdir                => $forwarder_confdir,
     purge_forwarder_deploymentclient => $purge_deploymentclient,
     purge_forwarder_outputs          => $purge_outputs,
     purge_forwarder_inputs           => $purge_inputs,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Ran into issues with getting the splunk forwarder installation working when installing it into a different directory.  splunkforwarder_web passes into splunk's ini_setting for determining the file_path, which pulls from splunk_config, but that isn't set within forwarder.  This pull just adds support for that.

The spec test for the forwarder class just has the compile with deps, so I didn't add anything to test values of the path for it.

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
