### PR TITLE
This commit fixes the error in startup 7.1.x

### DIFF
--- a/manifests/platform/posix.pp
+++ b/manifests/platform/posix.pp
@@ -27,7 +27,7 @@ class splunk::platform::posix (
   # Commands to run to enable the SplunkUniversalForwarder
   @exec { 'license_splunkforwarder':
     path    => "${splunk::params::forwarder_dir}/bin",
-    command => 'splunk start --accept-license --answer-yes',
+    command => 'splunk start --accept-license --answer-yes --no-prompt',
     user    => $splunk_user,
     creates => '/opt/splunkforwarder/etc/auth/server.pem',
     timeout => 0,
@@ -46,7 +46,7 @@ class splunk::platform::posix (
   # Commands to run to enable full Splunk
   @exec { 'license_splunk':
     path    => "${splunk::params::server_dir}/bin",
-    command => 'splunk start --accept-license --answer-yes',
+    command => 'splunk start --accept-license --answer-yes --no-prompt',
     user    => $splunk_user,
     creates => '/opt/splunk/etc/auth/splunk.secret',
     timeout => 0,


### PR DESCRIPTION
When splunk is started the first time on 7.1.x (and
higher) there is input expected, disable this with
--no-prompt. Fixes #186

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Installation of 7.1.x RPM's ask for input of a password

#### This Pull Request (PR) fixes the following issues
Fixes issue #186 