### PR TITLE
Allow empty local and outputs files to keep centralized Splunk happier.

### DIFF
--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -118,10 +118,10 @@ class splunk::forwarder (
 
   # Declare inputs and outputs specific to the forwarder profile
   $tag_resources = { tag => 'splunk_forwarder' }
-  if $forwarder_input != undef {
+  if $forwarder_input {
     create_resources( 'splunkforwarder_input',$forwarder_input, $tag_resources)
   }
-  if $forwarder_output != undef {
+  if $forwarder_output {
     create_resources( 'splunkforwarder_output',$forwarder_output, $tag_resources)
   }
   # this is default

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -38,6 +38,12 @@
 #   If set to true, will remove any outputs.conf configuration not supplied by
 #   Puppet from the target system. Defaults to false.
 #
+# [*forwarder_output*]
+#   Hash of output configs.  If undefined will not populate the outputs.conf file.
+#
+# [*forwarder_input*]
+#   Hash of input configs.  If undefined will not populate the inputs.conf file.
+#
 # Actions:
 #
 #   Declares parameters to be consumed by other classes in the splunk module.
@@ -112,8 +118,12 @@ class splunk::forwarder (
 
   # Declare inputs and outputs specific to the forwarder profile
   $tag_resources = { tag => 'splunk_forwarder' }
-  create_resources( 'splunkforwarder_input',$forwarder_input, $tag_resources)
-  create_resources( 'splunkforwarder_output',$forwarder_output, $tag_resources)
+  if $forwarder_input != undef {
+    create_resources( 'splunkforwarder_input',$forwarder_input, $tag_resources)
+  }
+  if $forwarder_output != undef {
+    create_resources( 'splunkforwarder_output',$forwarder_output, $tag_resources)
+  }
   # this is default
   splunkforwarder_web { 'forwarder_splunkd_port':
     section => 'settings',

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -10,13 +10,13 @@ describe 'splunk::forwarder' do
       end
 
       context 'with forwarder_output set to undef' do
-        let(:params) { { forwarder_output => :undef } }
+        let(:params) { { :forwarder_output => :undef } }
 
         it { is_expected.to compile.with_all_deps }
       end
 
       context 'with forwarder_input set to undef' do
-        let(:params) { { forwarder_input => :undef } }
+        let(:params) { { :forwarder_input => :undef } }
 
         it { is_expected.to compile.with_all_deps }
       end

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -11,11 +11,13 @@ describe 'splunk::forwarder' do
 
       context 'with forwarder_output set to undef' do
         let(:params) { { forwarder_output => :undef } }
+
         it { is_expected.to compile.with_all_deps }
       end
 
       context 'with forwarder_input set to undef' do
         let(:params) { { forwarder_input => :undef } }
+
         it { is_expected.to compile.with_all_deps }
       end
     end

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -10,13 +10,13 @@ describe 'splunk::forwarder' do
       end
 
       context 'with forwarder_output set to undef' do
-        let(:params) { { :forwarder_output => :undef } }
+        let(:params) { { 'forwarder_output' => :undef } }
 
         it { is_expected.to compile.with_all_deps }
       end
 
       context 'with forwarder_input set to undef' do
-        let(:params) { { :forwarder_input => :undef } }
+        let(:params) { { 'forwarder_input' => :undef } }
 
         it { is_expected.to compile.with_all_deps }
       end

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -8,6 +8,16 @@ describe 'splunk::forwarder' do
       context 'with defaults' do
         it { is_expected.to compile.with_all_deps }
       end
+
+      context 'with forwarder_outputs set to undef' do
+        let(:params) { forwarder_outputs => :undef }
+        it { is_expected.to compile.with_all_deps }
+      end
+
+      context 'with forwarder_inputs set to undef' do
+        let(:params) { forwarder_inputs => :undef }
+        it { is_expected.to compile.with_all_deps }
+      end
     end
   end
 end

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -9,13 +9,13 @@ describe 'splunk::forwarder' do
         it { is_expected.to compile.with_all_deps }
       end
 
-      context 'with forwarder_outputs set to undef' do
-        let(:params) { { forwarder_outputs => :undef } }
+      context 'with forwarder_output set to undef' do
+        let(:params) { { forwarder_output => :undef } }
         it { is_expected.to compile.with_all_deps }
       end
 
-      context 'with forwarder_inputs set to undef' do
-        let(:params) { { forwarder_inputs => :undef } }
+      context 'with forwarder_input set to undef' do
+        let(:params) { { forwarder_input => :undef } }
         it { is_expected.to compile.with_all_deps }
       end
     end

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -10,12 +10,12 @@ describe 'splunk::forwarder' do
       end
 
       context 'with forwarder_outputs set to undef' do
-        let(:params) { forwarder_outputs => :undef }
+        let(:params) { { forwarder_outputs => :undef } }
         it { is_expected.to compile.with_all_deps }
       end
 
       context 'with forwarder_inputs set to undef' do
-        let(:params) { forwarder_inputs => :undef }
+        let(:params) { { forwarder_inputs => :undef } }
         it { is_expected.to compile.with_all_deps }
       end
     end


### PR DESCRIPTION

#### Pull Request (PR) description
Splunk environments where the majority of the configuration is handled by splunk do not necessarily like these defaults. So allow a way to not provide them. Either by setting undef or passing empty (nil) from hiera.

