### PR TITLE
Add splunkforwarder_version fact

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -8,6 +8,7 @@
   - set: ubuntu1404-64
   - set: ubuntu1604-64
 spec/spec_helper.rb:
+  mock_with: :rspec
   spec_overrides: 
   - "require 'splunk_data.rb'"
   - "$LOAD_PATH.unshift File.dirname(__FILE__) + '/fixtures/modules/inifile/lib'"

--- a/lib/facter/splunk_version.rb
+++ b/lib/facter/splunk_version.rb
@@ -1,0 +1,17 @@
+Facter.add(:splunk_version) do
+  setcode do
+    value = nil
+    cmd = if File.exist?('C:/Program Files/Splunk/bin/splunk.exe')
+            '"C:/Program Files/Splunk/bin/splunk.exe" --version'
+          elsif File.exist?('/opt/splunk/bin/splunk')
+            '/opt/splunk/bin/splunk --version'
+          end
+    if cmd
+      output = Facter::Util::Resolution.exec(cmd)
+      if output =~ %r{^Splunk ([0-9\.]+) \(} # rubocop:disable Style/IfUnlessModifier
+        value = Regexp.last_match(1)
+      end
+    end
+    value
+  end
+end

--- a/lib/facter/splunkforwarder_version.rb
+++ b/lib/facter/splunkforwarder_version.rb
@@ -1,0 +1,17 @@
+Facter.add(:splunkforwarder_version) do
+  setcode do
+    value = nil
+    cmd = if File.exist?('C:/Program Files/SplunkUniversalForwarder/bin/splunk.exe')
+            '"C:/Program Files/SplunkUniversalForwarder/bin/splunk.exe" --version'
+          elsif File.exist?('/opt/splunkforwarder/bin/splunk')
+            '/opt/splunkforwarder/bin/splunk --version'
+          end
+    if cmd
+      output = Facter::Util::Resolution.exec(cmd)
+      if output =~ %r{^Splunk Universal Forwarder ([0-9\.]+) \(}
+        value = Regexp.last_match(1)
+      end
+    end
+    value
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 # This file is managed via modulesync
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts

--- a/spec/unit/facter/splunk_version_spec.rb
+++ b/spec/unit/facter/splunk_version_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'splunk_version Fact' do
+  before do
+    Facter.clear
+  end
+
+  it 'returns version for Windows' do
+    allow(File).to receive(:exist?).with('C:/Program Files/Splunk/bin/splunk.exe').and_return(true)
+    allow(Facter::Util::Resolution).to receive(:exec).with('"C:/Program Files/Splunk/bin/splunk.exe" --version').and_return('Splunk 6.6.8 (build 6c27a8439c1e)')
+    expect(Facter.fact(:splunk_version).value).to eq('6.6.8')
+  end
+
+  it 'returns version for Linux' do
+    allow(File).to receive(:exist?).with('C:/Program Files/Splunk/bin/splunk.exe').and_return(false)
+    allow(File).to receive(:exist?).with('/opt/splunk/bin/splunk').and_return(true)
+    allow(Facter::Util::Resolution).to receive(:exec).with('/opt/splunk/bin/splunk --version').and_return('Splunk 6.6.8 (build 6c27a8439c1e)')
+    expect(Facter.fact(:splunk_version).value).to eq('6.6.8')
+  end
+
+  it 'returns nil' do
+    allow(File).to receive(:exist?).with('C:/Program Files/Splunk/bin/splunk.exe').and_return(false)
+    allow(File).to receive(:exist?).with('/opt/splunk/bin/splunk').and_return(false)
+    expect(Facter.fact(:splunk_version).value).to be_nil
+  end
+end

--- a/spec/unit/facter/splunkforwarder_version_spec.rb
+++ b/spec/unit/facter/splunkforwarder_version_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'splunkforwarder_version Fact' do
+  before do
+    Facter.clear
+  end
+
+  it 'returns version for Windows' do
+    allow(File).to receive(:exist?).with('C:/Program Files/SplunkUniversalForwarder/bin/splunk.exe').and_return(true)
+    allow(Facter::Util::Resolution).to receive(:exec).with('"C:/Program Files/SplunkUniversalForwarder/bin/splunk.exe" --version').and_return('Splunk Universal Forwarder 7.0.2 (build 03bbabbd5c0f)')
+    expect(Facter.fact(:splunkforwarder_version).value).to eq('7.0.2')
+  end
+
+  it 'returns version for Linux' do
+    allow(File).to receive(:exist?).with('C:/Program Files/SplunkUniversalForwarder/bin/splunk.exe').and_return(false)
+    allow(File).to receive(:exist?).with('/opt/splunkforwarder/bin/splunk').and_return(true)
+    allow(Facter::Util::Resolution).to receive(:exec).with('/opt/splunkforwarder/bin/splunk --version').and_return('Splunk Universal Forwarder 7.0.2 (build 03bbabbd5c0f)')
+    expect(Facter.fact(:splunkforwarder_version).value).to eq('7.0.2')
+  end
+
+  it 'returns nil' do
+    allow(File).to receive(:exist?).with('C:/Program Files/SplunkUniversalForwarder/bin/splunk.exe').and_return(false)
+    allow(File).to receive(:exist?).with('/opt/splunkforwarder/bin/splunk').and_return(false)
+    expect(Facter.fact(:splunkforwarder_version).value).to be_nil
+  end
+end


### PR DESCRIPTION
Adds `splunkfowarder_version` fact that works for both Linux and Windows.