### PR TITLE
Compare decrypted values to see if they are insync

### DIFF
--- a/lib/puppet_x/puppetlabs/splunk/type.rb
+++ b/lib/puppet_x/puppetlabs/splunk/type.rb
@@ -1,3 +1,5 @@
+require File.join(File.dirname(__FILE__), '..', '..', 'voxpupuli/splunk/util')
+
 module PuppetX
   module Puppetlabs
     module Splunk
@@ -25,6 +27,15 @@ module PuppetX
             desc 'The value of the setting to be defined.'
             munge do |v|
               v.to_s.strip
+            end
+            def insync?(is) # rubocop:disable Lint/NestedMethodDefinition
+              secrets_file_path = File.join(provider.class.file_path, 'auth/splunk.secret')
+              if File.file?(secrets_file_path)
+                PuppetX::Voxpupuli::Splunk::Util.decrypt(secrets_file_path, is) == should
+              else
+                Puppet.warning('Secrets file NOT found')
+                is == should
+              end
             end
           end
           type.newparam(:setting) do

--- a/lib/puppet_x/voxpupuli/splunk/util.rb
+++ b/lib/puppet_x/voxpupuli/splunk/util.rb
@@ -1,0 +1,32 @@
+require 'openssl'
+require 'base64'
+
+module PuppetX
+  module Voxpupuli
+    module Splunk
+      class Util
+        def self.decrypt(secrets_file, value)
+          return value unless value.start_with?('$7$')
+
+          Puppet.debug "Decrypting splunk >= 7.2 data using secret from #{secrets_file}"
+          value.slice!(0, 3)
+          data = Base64.strict_decode64(value)
+          splunk_secret = IO.binread(secrets_file).chomp
+
+          iv         = data.bytes[0, 16].pack('c*')
+          tag        = data.bytes[-16..-1].pack('c*')
+          ciphertext = data.bytes[16..-17].pack('c*')
+
+          decipher = OpenSSL::Cipher::AES.new(256, :GCM).decrypt
+          decipher.key = OpenSSL::PKCS5.pbkdf2_hmac(splunk_secret, 'disk-encryption', 1, 32, OpenSSL::Digest::SHA256.new)
+          decipher.iv_len = 16
+          decipher.iv = iv
+          decipher.auth_tag = tag
+          decipher.auth_data = ''
+
+          decipher.update(ciphertext) + decipher.final
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/splunk_forwarder_spec.rb
+++ b/spec/acceptance/splunk_forwarder_spec.rb
@@ -5,16 +5,25 @@ describe 'splunk::forwarder class' do
     # Using puppet_apply as a helper
     it 'works idempotently with no errors' do
       pp = <<-EOS
-      class { '::splunk::params':
+      class { 'splunk::params':
       }
-      class { '::splunk::forwarder':
+      class { 'splunk::forwarder':
         splunkd_port => 8090,
+      }
+      splunkforwarder_output { 'tcpout:splunkcloud/sslPassword':
+        value => 'super_secure_password',
       }
       EOS
 
       # Run it twice and test for idempotency
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/opt/splunkforwarder/etc/system/local/outputs.conf') do
+      it { is_expected.to be_file }
+      its(:content) { is_expected.to match %r{^sslPassword} }
+      its(:content) { is_expected.to match %r{^sslPassword = \$7\$} }
     end
 
     describe package('splunkforwarder') do

--- a/spec/unit/puppet_x/voxpupuli/splunk/util_spec.rb
+++ b/spec/unit/puppet_x/voxpupuli/splunk/util_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require 'puppet_x/voxpupuli/splunk/util'
+
+describe PuppetX::Voxpupuli::Splunk::Util do
+  describe '.decrypt' do
+    context 'when called with an unencrypted value' do
+      it 'returns the value unmodified' do
+        expect(described_class.decrypt('secrets_file', 'non_encrypted_value')).to eq 'non_encrypted_value'
+      end
+    end
+    context 'when called with splunk 7.2 encrypted value' do
+      let(:encrypted_value) { '$7$aTVkS01HYVNJUk5wSnR5NIu4GXLhj2Qd49n2B6Y8qmA/u1CdL9JYxQ==' }
+      let(:splunk_secret) { 'JX7cQAnH6Nznmild8MvfN8/BLQnGr8C3UYg3mqvc3ArFkaxj4gUt1RUCaRBD/r0CNn8xOA2oKX8/0uyyChyGRiFKhp6h2FA+ydNIRnN46N8rZov8QGkchmebZa5GAM5U50GbCCgzJFObPyWi5yT8CrSCYmv9cpRtpKyiX+wkhJwltoJzAxWbBERiLp+oXZnN3lsRn6YkljmYBqN9tZLTVVpsLvqvkezPgpv727Fd//5dRoWsWBv2zRp0mwDv3tj' }
+
+      it 'returns decrypted value' do
+        allow(IO).to receive(:binread).with('secrets_file').and_return(splunk_secret)
+        expect(described_class.decrypt('secrets_file', encrypted_value)).to eq 'temp1234'
+      end
+    end
+  end
+end


### PR DESCRIPTION
When splunk is started, it automatically encrypts certain values when it
finds them in config files.  To stop puppet reverting these changes,
I've overriden `insync?` so that it performs the decryption before
comparing.

Currently only implemented for splunk >= 7.2

Based on description of algorithm in this python based project.
https://github.com/HurricaneLabs/splunksecrets