### PR TITLE
Address post-merge comments on PR #224

### DIFF
--- a/spec/defines/addon_spec.rb
+++ b/spec/defines/addon_spec.rb
@@ -1,7 +1,29 @@
 require 'spec_helper'
 
 describe 'splunk::addon' do
+  context 'fail if class prerequisit not declared' do
+    on_supported_os.each do |os, facts|
+      if os.start_with?('windows')
+        # Splunk Server not used supported on windows
+      else
+        context "on #{os}" do
+          let(:facts) do
+            facts
+          end
+          let(:title) { 'Splunk_TA' }
+          let(:params) { { 'splunkbase_source' => 'puppet:///modules/profiles/splunk-add-on.tgz' } }
+
+          it { is_expected.to raise_error(Puppet::Error) }
+        end
+      end
+    end
+  end
+
   context 'supported operating systems' do
+    let(:pre_condition) do
+      'include splunk::forwarder'
+    end
+
     on_supported_os.each do |os, facts|
       if os.start_with?('windows')
         # Splunk Server not used supported on windows


### PR DESCRIPTION
Removes declaration of Class[splunk::params] since it should already be in scope and declared by either Class[splunk::enterprise] or Class[splunk::forwarder] and removes an unnecessary test of an empty hash. Modifies Splunk::Addon spec test to address the removal of Class[splunk::params].