### PR TITLE
Optionally manage splunk user and group

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,10 @@ module. On Windows, this can be a UNC path to the MSI.  Defaults to undef.
 This variable is passed to the package resources' *install_options* parameter.
 Defaults to the value in ::splunk::params.
 
+#### `manage_splunk_user`
+
+Whether or not to manage the user splunk runuser.  Defaults to false.
+
 #### `splunk_user`
 
 The user to run Splunk as. Defaults to the value set in splunk::params.
@@ -572,6 +576,10 @@ module. On Windows, this can be a UNC path to the MSI.  Defaults to undef.
 
 This variable is passed to the package resources' *install_options* parameter.
 Defaults to the value in ::splunk::params.
+
+#### `manage_splunk_user`
+
+Whether or not to manage the user splunk runuser.  Defaults to false.
 
 #### `splunk_user`
 

--- a/manifests/enterprise.pp
+++ b/manifests/enterprise.pp
@@ -55,6 +55,10 @@
 # This variable is passed to the package resources' *install_options* parameter.
 # Defaults to the value in ::splunk::params.
 #
+# @param manage_splunk_user
+#
+# Whether or not to manage the splunk runuser.
+#
 # @param splunk_user
 #
 # The user to run Splunk as. Defaults to the value set in splunk::params.
@@ -209,6 +213,7 @@ class splunk::enterprise (
   Boolean $manage_package_source             = true,
   Optional[String[1]] $package_source        = undef,
   Array[String[1]] $install_options          = $splunk::params::enterprise_install_options,
+  Boolean $manage_splunk_user                = $splunk::params::manage_splunk_user,
   String[1] $splunk_user                     = $splunk::params::splunk_user,
   Stdlib::Absolutepath $enterprise_homedir   = $splunk::params::enterprise_homedir,
   Stdlib::Absolutepath $enterprise_confdir   = $splunk::params::enterprise_confdir,

--- a/manifests/enterprise/install.pp
+++ b/manifests/enterprise/install.pp
@@ -41,4 +41,16 @@ class splunk::enterprise::install {
     install_options => $splunk::enterprise::install_options,
   }
 
+  if $splunk::enterprise::manage_splunk_user {
+    group { $splunk::enterprise::splunk_user:
+      ensure  => 'present',
+      require => Package[$splunk::enterprise::enterprise_package_name],
+    }
+    user { $splunk::enterprise::splunk_user:
+      ensure  => 'present',
+      home    => $splunk::enterprise::enterprise_homedir,
+      require => Group[$splunk::enterprise::splunk_user],
+    }
+  }
+
 }

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -60,6 +60,10 @@
 # This variable is passed to the package resources' *install_options* parameter.
 # Defaults to the value in ::splunk::params.
 #
+# @param manage_splunk_user
+#
+# Whether or not to manage the splunk runuser.
+#
 # @param splunk_user
 #
 # The user to run Splunk as. Defaults to the value set in splunk::params.
@@ -183,6 +187,7 @@ class splunk::forwarder(
   Boolean $manage_package_source             = true,
   Optional[String[1]] $package_source        = undef,
   Array[String[1]] $install_options          = $splunk::params::forwarder_install_options,
+  Boolean $manage_splunk_user                = $splunk::params::manage_splunk_user,
   String[1] $splunk_user                     = $splunk::params::splunk_user,
   Stdlib::Absolutepath $forwarder_homedir    = $splunk::params::forwarder_homedir,
   Stdlib::Absolutepath $forwarder_confdir    = $splunk::params::forwarder_confdir,

--- a/manifests/forwarder/install.pp
+++ b/manifests/forwarder/install.pp
@@ -64,4 +64,16 @@ class splunk::forwarder::install {
     install_options => $splunk::forwarder::install_options,
   }
 
+  if $splunk::forwarder::manage_splunk_user {
+    group { $splunk::forwarder::splunk_user:
+      ensure  => 'present',
+      require => Package[$splunk::forwarder::forwarder_package_name],
+    }
+    user { $splunk::forwarder::splunk_user:
+      ensure  => 'present',
+      home    => $splunk::forwarder::forwarder_homedir,
+      require => Group[$splunk::forwarder::splunk_user],
+    }
+  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,6 +28,11 @@
 #   Optional fqdn or IP of the Splunk Enterprise server.  Used for setting up
 #   the default TCP output and input.
 #
+# @param manage_splunk_user
+#   Whether or not to manage the splunk runuser.
+#
+#   Defaults to false.
+#
 # @param splunk_user
 #   The user that splunk runs as.
 #
@@ -105,6 +110,7 @@ class splunk::params (
   Optional[String[1]] $forwarder_installdir  = undef,
   Optional[String[1]] $enterprise_installdir = undef,
   Boolean $boot_start                        = true,
+  Boolean $manage_splunk_user                = false,
   String[1] $splunk_user                     = $facts['os']['family'] ? {
     'Windows' => 'Administrator',
     default => 'root'

--- a/spec/acceptance/splunk_enterprise_spec.rb
+++ b/spec/acceptance/splunk_enterprise_spec.rb
@@ -47,7 +47,12 @@ describe 'splunk enterprise class' do
         service { '#{service_name}': ensure => stopped }
         package { 'splunk': ensure => purged }
         file { '/opt/splunk': ensure => absent, force => true, require => Package['splunk'] }
-        file { '/etc/init.d/splunk': ensure => absent, require => Package['splunk'] }
+        file { ['/etc/init.d/splunk',
+                '/etc/systemd/system/Splunkd.service',
+                '/etc/systemd/system/multi-user.target.wants/Splunkd.service']:
+          ensure => absent,
+          require => Package['splunk']
+        }
         EOS
         apply_manifest(pp, catch_failures: true)
       end

--- a/spec/classes/enterprise_spec.rb
+++ b/spec/classes/enterprise_spec.rb
@@ -12,6 +12,8 @@ shared_examples_for 'splunk enterprise nix defaults' do
   it { is_expected.to contain_class('splunk::enterprise::service::nix') }
   it { is_expected.to contain_splunk_config('splunk') }
   it { is_expected.to contain_package('splunk').with(ensure: 'installed') }
+  it { is_expected.not_to contain_user('root') }
+  it { is_expected.not_to contain_group('root') }
   it { is_expected.to contain_file('/opt/splunk/etc/system/local/alert_actions.conf') }
   it { is_expected.to contain_file('/opt/splunk/etc/system/local/authentication.conf') }
   it { is_expected.to contain_file('/opt/splunk/etc/system/local/authorize.conf') }
@@ -71,6 +73,14 @@ describe 'splunk::enterprise' do
 
               it { is_expected.to contain_package('splunk').with(provider: 'yum') }
             end
+          end
+
+          context 'when manage_splunk_user = true' do
+            let(:params) { { 'manage_splunk_user' => true, 'splunk_user' => 'splunk' } }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_user('splunk') }
+            it { is_expected.to contain_group('splunk') }
           end
 
           context 'with $boot_start = true (defaults)' do


### PR DESCRIPTION
* Declare the splunk user and group to properly ensure config files
  when the splunk user is anything but root
* Update acceptance clean-up for systemd-based installations

Fixes #223
