### PR TITLE
Make sure package is installed before calling execs

### DIFF
--- a/manifests/enterprise/service/nix.pp
+++ b/manifests/enterprise/service/nix.pp
@@ -16,6 +16,7 @@ class splunk::enterprise::service::nix inherits splunk::enterprise::service {
       creates => $splunk::enterprise::enterprise_service_file,
       timeout => 0,
       notify  => Exec['enable_splunk'],
+      require => Package[$splunk::enterprise::package_name],
     }
     if $splunk::params::supports_systemd and $splunk::enterprise::splunk_user == 'root' {
       $user_args = ''
@@ -41,6 +42,7 @@ class splunk::enterprise::service::nix inherits splunk::enterprise::service {
     exec { 'disable_splunk':
       command => "${splunk::enterprise::enterprise_homedir}/bin/splunk disable boot-start -user ${splunk::enterprise::splunk_user} --accept-license --answer-yes --no-prompt",
       onlyif  => "/usr/bin/test -f ${splunk::enterprise::enterprise_service_file}",
+      require => Package[$splunk::enterprise::package_name],
     }
     # This will start splunkd and splunkweb in legacy mode assuming
     # appServerPorts is set to 0.

--- a/manifests/forwarder/service/nix.pp
+++ b/manifests/forwarder/service/nix.pp
@@ -18,6 +18,7 @@ class splunk::forwarder::service::nix inherits splunk::forwarder::service {
       creates => $splunk::forwarder::forwarder_service_file,
       timeout => 0,
       notify  => Exec['enable_splunkforwarder'],
+      require => Package[$splunk::forwarder::package_name],
     }
     if $splunk::params::supports_systemd and $splunk::forwarder::splunk_user == 'root' {
       $user_args = ''
@@ -46,6 +47,7 @@ class splunk::forwarder::service::nix inherits splunk::forwarder::service {
     exec { 'disable_splunkforwarder':
       command => "${splunk::forwarder::forwarder_homedir}/bin/splunk disable boot-start -user ${splunk::forwarder::splunk_user} --accept-license --answer-yes --no-prompt",
       onlyif  => "/usr/bin/test -f ${splunk::forwarder::forwarder_service_file}",
+      require => Package[$splunk::forwarder::package_name],
     }
     exec { 'license_splunkforwarder':
       command => "${splunk::forwarder::forwarder_homedir}/bin/splunk ftr --accept-license --answer-yes --no-prompt",

--- a/spec/classes/enterprise_spec.rb
+++ b/spec/classes/enterprise_spec.rb
@@ -88,7 +88,7 @@ describe 'splunk::enterprise' do
                 it { is_expected.to contain_package('net-tools').with(ensure: 'present') }
                 it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'splunk') }
                 it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
-                it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop') }
+                it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop', require: 'Package[splunk]') }
                 it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunk') }
                 it { is_expected.not_to contain_exec('license_splunk') }
@@ -107,7 +107,7 @@ describe 'splunk::enterprise' do
                 it { is_expected.not_to contain_package('net-tools').with(ensure: 'present') }
                 it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'splunk') }
                 it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
-                it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop') }
+                it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop', require: 'Package[splunk]') }
                 it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunk') }
                 it { is_expected.not_to contain_exec('license_splunk') }
@@ -126,7 +126,7 @@ describe 'splunk::enterprise' do
                 it { is_expected.to contain_package('net-tools').with(ensure: 'present') }
                 it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'Splunkd') }
                 it { is_expected.to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
-                it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop') }
+                it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop', require: 'Package[splunk]') }
                 it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start  -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunk') }
                 it { is_expected.not_to contain_exec('license_splunk') }
@@ -157,7 +157,7 @@ describe 'splunk::enterprise' do
                 it { is_expected.not_to contain_package('net-tools').with(ensure: 'present') }
                 it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'splunk') }
                 it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
-                it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop') }
+                it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop', require: 'Package[splunk]') }
                 it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunk') }
                 it { is_expected.not_to contain_exec('license_splunk') }
@@ -184,7 +184,7 @@ describe 'splunk::enterprise' do
                 it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
                 it { is_expected.not_to contain_exec('stop_splunk') }
                 it { is_expected.not_to contain_exec('enable_splunk') }
-                it { is_expected.to contain_exec('disable_splunk').with(command: '/opt/splunk/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('disable_splunk').with(command: '/opt/splunk/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt', require: 'Package[splunk]') }
                 it { is_expected.to contain_exec('license_splunk').with(command: '/opt/splunk/bin/splunk start --accept-license --answer-yes --no-prompt') }
                 it { is_expected.to contain_service('splunk').with(restart: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk restart'", start: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk start'", stop: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk stop'", status: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk status'") }
               end
@@ -203,7 +203,7 @@ describe 'splunk::enterprise' do
                 it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
                 it { is_expected.not_to contain_exec('stop_splunk') }
                 it { is_expected.not_to contain_exec('enable_splunk') }
-                it { is_expected.to contain_exec('disable_splunk').with(command: '/opt/splunk/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('disable_splunk').with(command: '/opt/splunk/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt', require: 'Package[splunk]') }
                 it { is_expected.to contain_exec('license_splunk').with(command: '/opt/splunk/bin/splunk start --accept-license --answer-yes --no-prompt') }
                 it { is_expected.to contain_service('splunk').with(restart: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk restart'", start: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk start'", stop: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk stop'", status: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk status'") }
               end
@@ -222,7 +222,7 @@ describe 'splunk::enterprise' do
                 it { is_expected.to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
                 it { is_expected.not_to contain_exec('stop_splunk') }
                 it { is_expected.not_to contain_exec('enable_splunk') }
-                it { is_expected.to contain_exec('disable_splunk').with(command: '/opt/splunk/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('disable_splunk').with(command: '/opt/splunk/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt', require: 'Package[splunk]') }
                 it { is_expected.to contain_exec('license_splunk').with(command: '/opt/splunk/bin/splunk start --accept-license --answer-yes --no-prompt') }
                 it { is_expected.to contain_service('Splunkd').with(restart: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk restart'", start: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk start'", stop: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk stop'", status: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk status'") }
               end
@@ -241,7 +241,7 @@ describe 'splunk::enterprise' do
                 it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
                 it { is_expected.not_to contain_exec('stop_splunk') }
                 it { is_expected.not_to contain_exec('enable_splunk') }
-                it { is_expected.to contain_exec('disable_splunk').with(command: '/opt/splunk/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('disable_splunk').with(command: '/opt/splunk/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt', require: 'Package[splunk]') }
                 it { is_expected.to contain_exec('license_splunk').with(command: '/opt/splunk/bin/splunk start --accept-license --answer-yes --no-prompt') }
                 it { is_expected.to contain_service('splunk').with(restart: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk restart'", start: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk start'", stop: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk stop'", status: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk status'") }
               end

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -75,7 +75,7 @@ describe 'splunk::forwarder' do
                 it_behaves_like 'splunk forwarder'
                 it { is_expected.to contain_class('splunk::forwarder::service::nix') }
                 it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'splunk') }
-                it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop') }
+                it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop', require: 'Package[splunkforwarder]') }
                 it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunkforwarder') }
                 it { is_expected.not_to contain_exec('license_splunkforwarder') }
@@ -93,7 +93,7 @@ describe 'splunk::forwarder' do
                 it_behaves_like 'splunk forwarder'
                 it { is_expected.to contain_class('splunk::forwarder::service::nix') }
                 it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'splunk') }
-                it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop') }
+                it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop', require: 'Package[splunkforwarder]') }
                 it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunkforwarder') }
                 it { is_expected.not_to contain_exec('license_splunkforwarder') }
@@ -111,7 +111,7 @@ describe 'splunk::forwarder' do
                 it_behaves_like 'splunk forwarder'
                 it { is_expected.to contain_class('splunk::forwarder::service::nix') }
                 it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'SplunkForwarder') }
-                it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop') }
+                it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop', require: 'Package[splunkforwarder]') }
                 it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start  -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunkforwarder') }
                 it { is_expected.not_to contain_exec('license_splunkforwarder') }
@@ -141,7 +141,7 @@ describe 'splunk::forwarder' do
                 it_behaves_like 'splunk forwarder'
                 it { is_expected.to contain_class('splunk::forwarder::service::nix') }
                 it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'splunk') }
-                it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop') }
+                it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop', require: 'Package[splunkforwarder]') }
                 it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunkforwarder') }
                 it { is_expected.not_to contain_exec('license_splunkforwarder') }
@@ -167,7 +167,7 @@ describe 'splunk::forwarder' do
                 it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'splunk') }
                 it { is_expected.not_to contain_exec('stop_splunkforwarder') }
                 it { is_expected.not_to contain_exec('enable_splunkforwarder') }
-                it { is_expected.to contain_exec('disable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('disable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt', require: 'Package[splunkforwarder]') }
                 it { is_expected.to contain_exec('license_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk ftr --accept-license --answer-yes --no-prompt') }
                 it { is_expected.to contain_service('splunk').with(restart: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk restart'", start: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk start'", stop: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk stop'", status: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk status'") }
               end
@@ -185,7 +185,7 @@ describe 'splunk::forwarder' do
                 it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'splunk') }
                 it { is_expected.not_to contain_exec('stop_splunkforwarder') }
                 it { is_expected.not_to contain_exec('enable_splunkforwarder') }
-                it { is_expected.to contain_exec('disable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('disable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt', require: 'Package[splunkforwarder]') }
                 it { is_expected.to contain_exec('license_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk ftr --accept-license --answer-yes --no-prompt') }
                 it { is_expected.to contain_service('splunk').with(restart: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk restart'", start: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk start'", stop: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk stop'", status: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk status'") }
               end
@@ -203,7 +203,7 @@ describe 'splunk::forwarder' do
                 it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'SplunkForwarder') }
                 it { is_expected.not_to contain_exec('stop_splunkforwarder') }
                 it { is_expected.not_to contain_exec('enable_splunkforwarder') }
-                it { is_expected.to contain_exec('disable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('disable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt', require: 'Package[splunkforwarder]') }
                 it { is_expected.to contain_exec('license_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk ftr --accept-license --answer-yes --no-prompt') }
                 it { is_expected.to contain_service('SplunkForwarder').with(restart: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk restart'", start: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk start'", stop: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk stop'", status: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk status'") }
               end
@@ -221,7 +221,7 @@ describe 'splunk::forwarder' do
                 it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'splunk') }
                 it { is_expected.not_to contain_exec('stop_splunkforwarder') }
                 it { is_expected.not_to contain_exec('enable_splunkforwarder') }
-                it { is_expected.to contain_exec('disable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('disable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt', require: 'Package[splunkforwarder]') }
                 it { is_expected.to contain_exec('license_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk ftr --accept-license --answer-yes --no-prompt') }
                 it { is_expected.to contain_service('splunk').with(restart: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk restart'", start: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk start'", stop: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk stop'", status: "/usr/sbin/runuser -l root -c '/opt/splunkforwarder/bin/splunk status'") }
               end


### PR DESCRIPTION
#### Pull Request (PR) description
To correct ordering in this module for our installations, we have had to do the following:

```puppet
Package[$::splunk::forwarder::forwarder_package_name] -> Exec[stop_splunkforwarder]
```

This seemed to just be a missing `require` in the module, which this PR attempts to correct.

#### This Pull Request (PR) fixes the following issues
n/a
