### PR TITLE
add secret_file parameter to Windows

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -194,6 +194,8 @@ class splunk::params (
       $enterprise_seed_config_file     = "${enterprise_homedir}\\etc\\system\\local\\user-seed.conf"
       $forwarder_password_config_file  = "${forwarder_homedir}\\etc\\passwd"
       $enterprise_password_config_file = "${enterprise_homedir}\\etc\\passwd"
+      $forwarder_secret_file           = "${forwarder_homedir}\\etc\\splunk.secret"
+      $enterprise_secret_file          = "${enterprise_homedir}\\etc\\splunk.secret"
       $forwarder_service               = 'SplunkForwarder'
       $forwarder_service_file          = "${forwarder_homedir}\\dummy" # Not used in Windows, but attribute must be defined with a valid path
       $forwarder_confdir               = "${forwarder_homedir}\\etc"


### PR DESCRIPTION
#### Pull Request (PR) description
adds the secret_file parameter to Windows

#### This Pull Request (PR) fixes the following issues
the secret_file parameter was missing for the Windows case in params.pp which was causing a catalog compilation failure with the following error:

```Error while evaluating a Resource Statement, Class[Splunk::Forwarder]: parameter 'secret_file' expects a Stdlib::Absolutepath = Variant[Stdlib::Windowspath = Pattern[/^(([a-zA-Z]:[\\\/])|([\\\/][\\\/][^\\\/]+[\\\/][^\\\/]+)|([\\\/][\\\/]\?[\\\/][^\\\/]+))/], Stdlib::Unixpath = Pattern[/^\/([^\/\0]+\/*)*$/]] value, got Undef```