### PR TITLE
make sure service::nix is completed before starting the service

### DIFF
--- a/manifests/forwarder/service.pp
+++ b/manifests/forwarder/service.pp
@@ -9,7 +9,7 @@ class splunk::forwarder::service {
   # there is non-generic configuration that needs to be declared in addition
   # to the agnostic resources declared here.
   if $facts['kernel'] in ['Linux', 'SunOS'] {
-    include splunk::forwarder::service::nix
+    contain splunk::forwarder::service::nix
   }
 
   service { $splunk::forwarder::service_name:


### PR DESCRIPTION
With `include` it was failing. So had to move it to `contain` which will make sure that its setup the licences thing.

```
Error: Could not start Service[splunk]: Execution of '/sbin/service splunk start' returned 2: Starting Splunk...
License not yet accepted, but executed with no-prompt flag.  Exiting.
Error: /Stage[main]/Splunk::Forwarder::Service/Service[splunk]/ensure: change from 'stopped' to 'running' failed: Could not start Service[splunk]: Execution of '/sbin/service splunk start' returned 2: Starting Splunk...
License not yet accepted, but executed with no-prompt flag.  Exiting. (corrective)
```