### PR TITLE
Fix flaky acceptance tests

### DIFF
--- a/manifests/enterprise/config.pp
+++ b/manifests/enterprise/config.pp
@@ -14,6 +14,7 @@ class splunk::enterprise::config() {
       secret                => $splunk::enterprise::secret,
       splunk_user           => $splunk::enterprise::splunk_user,
       mode                  => 'agent',
+      notify                => Class['splunk::enterprise::service'],
     }
   }
 
@@ -26,6 +27,7 @@ class splunk::enterprise::config() {
       secret               => $splunk::enterprise::secret,
       splunk_user          => $splunk::enterprise::splunk_user,
       mode                 => 'agent',
+      notify               => Class['splunk::enterprise::service'],
     }
   }
 


### PR DESCRIPTION
	This commit adds relationship that's getting lost in a sea of
	containment layers that ensures Splunk services are restarted
	before the test checks for success or not.

	Without this the test fails in certain random situations and
	likely in a limited number of real world cases as well.