### PR TITLE
Fix systemd support and service subclass ordering

### DIFF
--- a/manifests/enterprise.pp
+++ b/manifests/enterprise.pp
@@ -247,6 +247,16 @@ class splunk::enterprise (
   -> Class['splunk::enterprise::config']
   ~> Class['splunk::enterprise::service']
 
+  # This is a module that supports multiple platforms. For some platforms
+  # there is non-generic configuration that needs to be declared in addition
+  # to the agnostic resources declared here.
+  if $facts['kernel'] in ['Linux','SunOS'] {
+    contain 'splunk::enterprise::service::nix'
+    Class['splunk::enterprise::config']
+    -> Class['splunk::enterprise::service::nix']
+    -> Class['splunk::enterprise::service']
+  }
+
   # Purge resources if option set
   Splunk_config['splunk'] {
     purge_alert_actions    => $purge_alert_actions,

--- a/manifests/enterprise/service.pp
+++ b/manifests/enterprise/service.pp
@@ -5,13 +5,6 @@
 #
 class splunk::enterprise::service {
 
-  # This is a module that supports multiple platforms. For some platforms
-  # there is non-generic configuration that needs to be declared in addition
-  # to the agnostic resources declared here.
-  if $facts['kernel'] in ['Linux','SunOS'] {
-    contain 'splunk::enterprise::service::nix'
-  }
-
   service { $splunk::enterprise::service_name:
     ensure     => running,
     enable     => true,

--- a/manifests/enterprise/service.pp
+++ b/manifests/enterprise/service.pp
@@ -9,7 +9,7 @@ class splunk::enterprise::service {
   # there is non-generic configuration that needs to be declared in addition
   # to the agnostic resources declared here.
   if $facts['kernel'] in ['Linux','SunOS'] {
-    include splunk::enterprise::service::nix
+    contain 'splunk::enterprise::service::nix'
   }
 
   service { $splunk::enterprise::service_name:

--- a/manifests/enterprise/service/nix.pp
+++ b/manifests/enterprise/service/nix.pp
@@ -17,11 +17,16 @@ class splunk::enterprise::service::nix inherits splunk::enterprise::service {
       timeout => 0,
       notify  => Exec['enable_splunk'],
     }
+    if $splunk::params::supports_systemd and $splunk::enterprise::splunk_user == 'root' {
+      $user_args = ''
+    } else {
+      $user_args = "-user ${splunk::enterprise::splunk_user}"
+    }
     # This will fail if the unit file already exists.  Splunk does not remove
     # unit files during uninstallation, so you may be required to manually
     # remove existing unit files before re-installing and enabling boot-start.
     exec { 'enable_splunk':
-      command     => "${splunk::enterprise::enterprise_homedir}/bin/splunk enable boot-start -user ${splunk::enterprise::splunk_user} --accept-license --answer-yes --no-prompt",
+      command     => "${splunk::enterprise::enterprise_homedir}/bin/splunk enable boot-start ${user_args} ${splunk::params::boot_start_args} --accept-license --answer-yes --no-prompt",
       refreshonly => true,
       before      => Service[$splunk::enterprise::service_name],
       require     => Exec['stop_splunk'],

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -218,6 +218,16 @@ class splunk::forwarder(
   -> Class['splunk::forwarder::config']
   ~> Class['splunk::forwarder::service']
 
+  # This is a module that supports multiple platforms. For some platforms
+  # there is non-generic configuration that needs to be declared in addition
+  # to the agnostic resources declared here.
+  if $facts['kernel'] in ['Linux', 'SunOS'] {
+    contain 'splunk::forwarder::service::nix'
+    Class['splunk::forwarder::config']
+    -> Class['splunk::forwarder::service::nix']
+    -> Class['splunk::forwarder::service']
+  }
+
   Splunk_config['splunk'] {
     forwarder_confdir                => $forwarder_confdir,
     purge_forwarder_deploymentclient => $purge_deploymentclient,

--- a/manifests/forwarder/service.pp
+++ b/manifests/forwarder/service.pp
@@ -5,13 +5,6 @@
 #
 class splunk::forwarder::service {
 
-  # This is a module that supports multiple platforms. For some platforms
-  # there is non-generic configuration that needs to be declared in addition
-  # to the agnostic resources declared here.
-  if $facts['kernel'] in ['Linux', 'SunOS'] {
-    contain 'splunk::forwarder::service::nix'
-  }
-
   service { $splunk::forwarder::service_name:
     ensure     => running,
     enable     => true,

--- a/manifests/forwarder/service.pp
+++ b/manifests/forwarder/service.pp
@@ -9,7 +9,7 @@ class splunk::forwarder::service {
   # there is non-generic configuration that needs to be declared in addition
   # to the agnostic resources declared here.
   if $facts['kernel'] in ['Linux', 'SunOS'] {
-    include splunk::forwarder::service::nix
+    contain 'splunk::forwarder::service::nix'
   }
 
   service { $splunk::forwarder::service_name:

--- a/manifests/forwarder/service/nix.pp
+++ b/manifests/forwarder/service/nix.pp
@@ -17,11 +17,16 @@ class splunk::forwarder::service::nix inherits splunk::forwarder::service {
       timeout => 0,
       notify  => Exec['enable_splunkforwarder'],
     }
+    if $splunk::params::supports_systemd and $splunk::forwarder::splunk_user == 'root' {
+      $user_args = ''
+    } else {
+      $user_args = "-user ${splunk::forwarder::splunk_user}"
+    }
     # This will fail if the unit file already exists.  Splunk does not remove
     # unit files during uninstallation, so you may be required to manually
     # remove existing unit files before re-installing and enabling boot-start.
     exec { 'enable_splunkforwarder':
-      command     => "${splunk::forwarder::forwarder_homedir}/bin/splunk enable boot-start -user ${splunk::forwarder::splunk_user} --accept-license --answer-yes --no-prompt",
+      command     => "${splunk::forwarder::forwarder_homedir}/bin/splunk enable boot-start ${user_args} ${splunk::params::boot_start_args} --accept-license --answer-yes --no-prompt",
       tag         => 'splunk_forwarder',
       refreshonly => true,
       before      => Service[$splunk::forwarder::service_name],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -151,12 +151,16 @@ class splunk::params (
         $forwarder_service       = 'SplunkForwarder'
         $enterprise_service_file = '/etc/systemd/system/multi-user.target.wants/Splunkd.service'
         $forwarder_service_file  = '/etc/systemd/system/multi-user.target.wants/SplunkForwarder.service'
+        $boot_start_args         = '-systemd-managed 1'
+        $supports_systemd        = true
       }
       else {
         $enterprise_service      = 'splunk'
         $forwarder_service       = 'splunk'
         $enterprise_service_file = '/etc/init.d/splunk'
         $forwarder_service_file  = '/etc/init.d/splunk'
+        $boot_start_args         = ''
+        $supports_systemd        = false
       }
     }
     'SunOS': {
@@ -179,12 +183,16 @@ class splunk::params (
         $forwarder_service       = 'SplunkForwarder'
         $enterprise_service_file = '/etc/systemd/system/multi-user.target.wants/Splunkd.service'
         $forwarder_service_file  = '/etc/systemd/system/multi-user.target.wants/SplunkForwarder.service'
+        $boot_start_args         = '-systemd-managed 1'
+        $supports_systemd        = true
       }
       else {
         $enterprise_service      = 'splunk'
         $forwarder_service       = 'splunk'
         $enterprise_service_file = '/etc/init.d/splunk'
         $forwarder_service_file  = '/etc/init.d/splunk'
+        $boot_start_args         = ''
+        $supports_systemd        = false
       }
     }
     'windows': {

--- a/spec/classes/enterprise_spec.rb
+++ b/spec/classes/enterprise_spec.rb
@@ -89,7 +89,7 @@ describe 'splunk::enterprise' do
                 it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'splunk') }
                 it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
                 it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop') }
-                it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunk') }
                 it { is_expected.not_to contain_exec('license_splunk') }
                 it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
@@ -108,7 +108,7 @@ describe 'splunk::enterprise' do
                 it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'splunk') }
                 it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
                 it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop') }
-                it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunk') }
                 it { is_expected.not_to contain_exec('license_splunk') }
                 it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
@@ -127,10 +127,22 @@ describe 'splunk::enterprise' do
                 it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'Splunkd') }
                 it { is_expected.to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
                 it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop') }
-                it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start  -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunk') }
                 it { is_expected.not_to contain_exec('license_splunk') }
                 it { is_expected.to contain_service('Splunkd').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
+              end
+
+              context 'with $facts[service_provider] == systemd and $splunk::params::version >= 7.2.2 and user != root' do
+                let(:facts) do
+                  facts.merge(service_provider: 'systemd')
+                end
+                let(:pre_condition) do
+                  "class { 'splunk::params': version => '7.2.4.2' }"
+                end
+                let(:params) { { splunk_user: 'splunk' } }
+
+                it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start -user splunk -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
               end
 
               context 'with $facts[service_provider] == systemd and $splunk::params::version < 7.2.2' do
@@ -146,7 +158,7 @@ describe 'splunk::enterprise' do
                 it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'splunk') }
                 it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
                 it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop') }
-                it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunk') }
                 it { is_expected.not_to contain_exec('license_splunk') }
                 it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -76,7 +76,7 @@ describe 'splunk::forwarder' do
                 it { is_expected.to contain_class('splunk::forwarder::service::nix') }
                 it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'splunk') }
                 it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop') }
-                it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunkforwarder') }
                 it { is_expected.not_to contain_exec('license_splunkforwarder') }
                 it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
@@ -94,7 +94,7 @@ describe 'splunk::forwarder' do
                 it { is_expected.to contain_class('splunk::forwarder::service::nix') }
                 it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'splunk') }
                 it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop') }
-                it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunkforwarder') }
                 it { is_expected.not_to contain_exec('license_splunkforwarder') }
                 it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
@@ -112,10 +112,22 @@ describe 'splunk::forwarder' do
                 it { is_expected.to contain_class('splunk::forwarder::service::nix') }
                 it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'SplunkForwarder') }
                 it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop') }
-                it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start  -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunkforwarder') }
                 it { is_expected.not_to contain_exec('license_splunkforwarder') }
                 it { is_expected.to contain_service('SplunkForwarder').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
+              end
+
+              context 'with $facts[service_provider] == systemd and $splunk::params::version >= 7.2.2 and user != root' do
+                let(:facts) do
+                  facts.merge(service_provider: 'systemd')
+                end
+                let(:pre_condition) do
+                  "class { 'splunk::params': version => '7.2.2' }"
+                end
+                let(:params) { { splunk_user: 'splunk' } }
+
+                it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user splunk -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
               end
 
               context 'with $facts[service_provider] == systemd and $splunk::params::version < 7.2.2' do
@@ -130,7 +142,7 @@ describe 'splunk::forwarder' do
                 it { is_expected.to contain_class('splunk::forwarder::service::nix') }
                 it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'splunk') }
                 it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop') }
-                it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunkforwarder') }
                 it { is_expected.not_to contain_exec('license_splunkforwarder') }
                 it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Fix execution of `splunk enable boot-start` to actually work with systemd systems and also to not specify `-user` when root is the user and also supporting systemd to avoid unnecessary `chown` lines in unit file per 7.3.2 docs.

Also fix order of service subclasses so they are applied after packages and configs.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
Fixes #262 
Fixes #263 