### PR TITLE
Support upgrading splunk forwarding and accepting ToS

### DIFF
--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -228,6 +228,54 @@ describe 'splunk::forwarder' do
 
             end
           end
+
+          context 'when forwarder not already installed' do
+            let(:facts) do
+              facts.merge(splunkforwarder_version: nil, service_provider: 'systemd')
+            end
+            let(:pre_condition) do
+              "class { 'splunk::params': version => '7.2.2' }"
+            end
+            let(:accept_tos_command) do
+              '/opt/splunkforwarder/bin/splunk stop && /opt/splunkforwarder/bin/splunk start --accept-license --answer-yes && /opt/splunkforwarder/bin/splunk stop'
+            end
+
+            it_behaves_like 'splunk forwarder'
+            it do
+              is_expected.to contain_exec('splunk-forwarder-accept-tos').with(
+                command: accept_tos_command,
+                user: 'root',
+                before: 'Service[SplunkForwarder]',
+                subscribe: nil,
+                require: 'Exec[enable_splunkforwarder]',
+                refreshonly: 'true'
+              )
+            end
+          end
+
+          context 'when forwarder already installed' do
+            let(:facts) do
+              facts.merge(splunkforwarder_version: '7.3.3', service_provider: 'systemd')
+            end
+            let(:pre_condition) do
+              "class { 'splunk::params': version => '7.2.2' }"
+            end
+            let(:accept_tos_command) do
+              '/opt/splunkforwarder/bin/splunk stop && /opt/splunkforwarder/bin/splunk start --accept-license --answer-yes && /opt/splunkforwarder/bin/splunk stop'
+            end
+
+            it_behaves_like 'splunk forwarder'
+            it do
+              is_expected.to contain_exec('splunk-forwarder-accept-tos').with(
+                command: accept_tos_command,
+                user: 'root',
+                before: 'Service[SplunkForwarder]',
+                subscribe: 'Package[splunkforwarder]',
+                require: 'Exec[enable_splunkforwarder]',
+                refreshonly: 'true'
+              )
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Based on Splunk docs (https://docs.splunk.com/Documentation/SplunkCloud/8.0.0/User/UpgradeyourForwarders) the way to upgrade forwarders is manually or with a script and that script essentially stops and then starts splunk with `--accept-license --assume-yes`. This tries to mimic that behavior.  The Exec should only be triggered if the forwarder is already installed.

Output from running this on my test and dev systems:

```
Notice: /Stage[main]/Splunk::Forwarder::Install/Package[splunkforwarder]/ensure: ensure changed '7.3.2-c60db69f8e32' to '0:7.3.3-7af3758d0d5e' (corrective)
Info: /Stage[main]/Splunk::Forwarder::Install/Package[splunkforwarder]: Scheduling refresh of Exec[splunk-forwarder-accept-tos]
Notice: /Stage[main]/Splunk::Forwarder::Service::Nix/Exec[splunk-forwarder-accept-tos]: Triggered 'refresh' from 1 event
Notice: /Stage[main]/Splunk::Forwarder::Service/Service[SplunkForwarder]/ensure: ensure changed 'stopped' to 'running' (corrective)
Info: /Stage[main]/Splunk::Forwarder::Service/Service[SplunkForwarder]: Unscheduling refresh on Service[SplunkForwarder]
```

The alternative to this PR is a Bolt task that handles the upgrade but the problem there is would get complicated to support all the ways Splunk forwarders can be installed (local RPM, local yum repo, etc).