### PR TITLE
Check if splunk forwarder was already installed when seeding password.

### DIFF
--- a/manifests/forwarder/password/seed.pp
+++ b/manifests/forwarder/password/seed.pp
@@ -57,7 +57,7 @@ class splunk::forwarder::password::seed(
     content => $secret,
   }
 
-  if $reset_seeded_password or $facts['splunk_version'].empty {
+  if $reset_seeded_password or $facts['splunkforwarder_version'].empty {
     file { $password_config_file:
       ensure => absent,
       before => File[$seed_config_file],


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Currently when seeding passwords for splunk::forwarder, it will continually re-seed unless you also have the splunk enterprise installed. This should resolve that.

#### This Pull Request (PR) fixes the following issues
n/a
