### PR TITLE
Add ability to override default-host configuration

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -106,7 +106,7 @@ class splunk::params (
     'windows' => 'Administrator',
     default => 'root'
   },
-  Optional[String[1]] $default_host          = $facts['clientcert'],
+  String[1] $default_host                    = $facts['clientcert'],
 ) {
   # Based on the small number of inputs above, we can construct sane defaults
   # for pretty much everything else.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -103,6 +103,7 @@ class splunk::params (
     'windows' => 'Administrator',
     default => 'root'
   },
+  Optional[String[1]] $default_host          = $facts['clientcert'],
 ) {
   # Based on the small number of inputs above, we can construct sane defaults
   # for pretty much everything else.
@@ -272,7 +273,7 @@ class splunk::params (
     'default_host' => {
       section      => 'default',
       setting      => 'host',
-      value        => $facts['clientcert'],
+      value        => $default_host,
       tag          => 'splunk_forwarder',
     },
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,6 +89,9 @@
 # @param enterprise_installdir
 #   Optional directory in which to install and manage Splunk Enterprise
 #
+# @param default_host
+#   The host property in inputs.conf. Defaults to the server's hostname.
+#
 class splunk::params (
   String[1] $version                         = '7.2.4.2',
   String[1] $build                           = 'fb30470262e3',


### PR DESCRIPTION
#### Pull Request (PR) description
Add ability to override default-host configuration. The default-host configuration is used to control the "host" property which Splunk will use to identify the forwarder. The current behaviour forces the default-host to match the server's $HOSTNAME. In my environment we prefer to customise this name to identify the region and environment for the forwarder (info we don't normally include in the server's hostname).

The default behaviour is maintained so this shouldn't break any existing setup. It just adds the ability to override it if required.

#### This Pull Request (PR) fixes the following issues
N/A
