### PR TITLE
change scope of resource override

### DIFF
--- a/manifests/forwarder/install.pp
+++ b/manifests/forwarder/install.pp
@@ -24,7 +24,7 @@ class splunk::forwarder::install {
     $_staged_package = undef
   }
 
-  Package  {
+  Package[$splunk::forwarder::package_name]  {
     source         => $splunk::forwarder::package_provider ? {
       'chocolatey' => undef,
       default      => $splunk::forwarder::manage_package_source ? {


### PR DESCRIPTION
#### Pull Request (PR) description
Pull request fixes a resource override scoping issue in splunk::forwarder::install.

When being installed on a machine with no existing installation of the net-tools package, the generic override of::

```puppet
Package  {
  source         => $splunk::forwarder::package_provider ? {
    'chocolatey' => undef,
    default      => $splunk::forwarder::manage_package_source ? {
      true  => pick($_staged_package, $_package_source),
      false => $_package_source,
    }
  },
}
```

Results in a net-tools resource of:

```puppet
package { 'net-tools':
  ensure => 'present',
  source => $splunk::forwarder::manage_package_source,
  before => Package[splunkforwarder],
}
```

#### This Pull Request (PR) fixes the following issues
n/a.
