### PR TITLE
Workaround a change in behavior of ensure_packages with stdlib

### DIFF
--- a/manifests/enterprise/install/nix.pp
+++ b/manifests/enterprise/install/nix.pp
@@ -34,7 +34,7 @@ class splunk::enterprise::install::nix inherits splunk::enterprise::install {
   if versioncmp($splunk::enterprise::version, '7.2.4.2') >= 0 {
     ensure_packages(['net-tools'], {
         'ensure' => 'present',
-        before   => Package[$splunk::enterprise::enterprise_package_name]
     })
+    Package['net-tools'] -> Package[$splunk::enterprise::enterprise_package_name]
   }
 }

--- a/manifests/forwarder/install.pp
+++ b/manifests/forwarder/install.pp
@@ -64,8 +64,8 @@ class splunk::forwarder::install {
   if ($facts['kernel'] == 'Linux' or $facts['kernel'] == 'SunOS') and (versioncmp($splunk::forwarder::version, '7.2.4.2') >= 0) {
     ensure_packages(['net-tools'], {
         'ensure' => 'present',
-        before   => Package[$splunk::forwarder::package_name]
     })
+    Package['net-tools'] -> Package[$splunk::forwarder::package_name]
   }
 
   package { $splunk::forwarder::package_name:


### PR DESCRIPTION
ensure_packages uses all parameters for the hash, but other instances
of ensure_packages['net-tools'] do not all specify exact this before option.

See https://tickets.puppetlabs.com/browse/MODULES-8733
Fixes #275
