### PR TITLE
Fix systemd service file locations to documented locations

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -148,8 +148,8 @@ class splunk::params (
       if $facts['service_provider'] == 'systemd' and versioncmp($version, '7.2.2') >= 0 {
         $enterprise_service      = 'Splunkd'
         $forwarder_service       = 'SplunkForwarder'
-        $enterprise_service_file = '/etc/systemd/system/multi-user.target.wants/Splunkd.service'
-        $forwarder_service_file  = '/etc/systemd/system/multi-user.target.wants/SplunkForwarder.service'
+        $enterprise_service_file = '/etc/systemd/system/Splunkd.service'
+        $forwarder_service_file  = '/etc/systemd/system/SplunkForwarder.service'
         $boot_start_args         = '-systemd-managed 1'
         $supports_systemd        = true
       }


### PR DESCRIPTION
The systemd service file locations are documented here:
https://docs.splunk.com/Documentation/Splunk/8.1.0/Admin/RunSplunkassystemdservice#Configure_systemd_using_enable_boot-start

Also the splunk installer looks for this file, not the symlink to it.
