### PR TITLE
Correct web_httpport field name

### DIFF
--- a/manifests/enterprise.pp
+++ b/manifests/enterprise.pp
@@ -91,7 +91,7 @@
 # @param splunkd_port
 #   The management port for Splunk.
 #
-# @param web_port
+# @param web_httpport
 #   The port on which to service the Splunk Web interface.
 #
 # @param purge_inputs


### PR DESCRIPTION
#### Pull Request (PR) description

This PR replaces the incorrect parameter name in the documentation for `splunk::enterprise::web_httpport`.

#### This Pull Request (PR) fixes the following issues

N/a
