### PR TITLE
update puppet-strings documentation

### DIFF
--- a/manifests/enterprise.pp
+++ b/manifests/enterprise.pp
@@ -144,7 +144,7 @@
 # @param seed_password
 #   If set to true, Manage the contents of splunk.secret and user-seed.conf.
 #
-# @param reset_seed_password
+# @param reset_seeded_password
 #   If set to true, deletes `password_config_file` to trigger Splunk's password
 #   import process on restart of the Splunk services.
 #

--- a/manifests/enterprise/password/manage.pp
+++ b/manifests/enterprise/password/manage.pp
@@ -21,11 +21,11 @@
 # @param secret
 #   The secret used to salt the splunk password.
 #
-# @params service
+# @param service
 #   Name of the Splunk Enterprise service that needs to be restarted after files
 #   are updated, not applicable when running in agent mode.
 #
-# @params mode
+# @param mode
 #   The class is designed to work in two ways, as a helper that is called by
 #   Class[splunk::enterprise::config] or leveraged independently from with in a
 #   Bolt Plan. The value defaults to "bolt" implicitly assuming that anytime it

--- a/manifests/enterprise/password/seed.pp
+++ b/manifests/enterprise/password/seed.pp
@@ -3,10 +3,7 @@
 #   so it can be used outside of regular management of the whole stack to
 #   facilitate admin password resets through Bolt Plans
 #
-# @param seed_password
-#   If set to true, Manage the contents of splunk.secret and user-seed.conf.
-#
-# @param reset_seed_password
+# @param reset_seeded_password
 #   If set to true, deletes `password_config_file` to trigger Splunk's password
 #   import process on restart of the Splunk services.
 #
@@ -27,11 +24,11 @@
 # @param secret
 #   The secret used to salt the splunk password.
 #
-# @params service
+# @param service
 #   Name of the Splunk Enterprise service that needs to be restarted after files
 #   are updated, not applicable when running in agent mode.
 #
-# @params mode
+# @param mode
 #   The class is designed to work in two ways, as a helper that is called by
 #   Class[splunk::enterprise::config] or leveraged independently from with in a
 #   Bolt Plan. The value defaults to "bolt" implicitly assuming that anytime it

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -17,7 +17,7 @@
 # @param server
 #   The fqdn or IP address of the Splunk server.
 #
-# @param version`
+# @param version
 #   Specifies the version of Splunk Forwarder the module should install and
 #   manage.
 #
@@ -120,7 +120,7 @@
 # @param seed_password
 #   If set to true, Manage the contents of splunk.secret and user-seed.conf.
 #
-# @param reset_seed_password
+# @param reset_seeded_password
 #   If set to true, deletes `password_config_file` to trigger Splunk's password
 #   import process on restart of the Splunk services.
 #

--- a/manifests/forwarder/password/manage.pp
+++ b/manifests/forwarder/password/manage.pp
@@ -21,11 +21,11 @@
 # @param secret
 #   The secret used to salt the splunk password.
 #
-# @params service
+# @param service
 #   Name of the Splunk Enterprise service that needs to be restarted after files
 #   are updated, not applicable when running in agent mode.
 #
-# @params mode
+# @param mode
 #   The class is designed to work in two ways, as a helper that is called by
 #   Class[splunk::forwarder::config] or leveraged independently from with in a
 #   Bolt Plan. The value defaults to "bolt" implicitly assuming that anytime it

--- a/manifests/forwarder/password/seed.pp
+++ b/manifests/forwarder/password/seed.pp
@@ -3,10 +3,7 @@
 #   so it can be used outside of regular management of the whole stack to
 #   facilitate admin password resets through Bolt Plans
 #
-# @param seed_password
-#   If set to true, Manage the contents of splunk.secret and user-seed.conf.
-#
-# @param reset_seed_password
+# @param reset_seeded_password
 #   If set to true, deletes `password_config_file` to trigger Splunk's password
 #   import process on restart of the Splunk services.
 #
@@ -27,11 +24,11 @@
 # @param secret
 #   The secret used to salt the splunk password.
 #
-# @params service
+# @param service
 #   Name of the Splunk Forwarder service that needs to be restarted after files
 #   are updated, not applicable when running in agent mode.
 #
-# @params mode
+# @param mode
 #   The class is designed to work in two ways, as a helper that is called by
 #   Class[splunk::forwarder::config] or leveraged independently from with in a
 #   Bolt Plan. The value defaults to "bolt" implicitly assuming that anytime it


### PR DESCRIPTION
I fixed some wrong puppet-strings tags. Sadly I cannot regenerate the
README.md??

```
rake aborted!
NoMethodError: undefined method `any?' for nil:NilClass
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings/yard/code_objects/type.rb:153:in `parameters'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings/yard/code_objects/type.rb:184:in `to_hash'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings/markdown/resource_types.rb:8:in `map!'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings/markdown/resource_types.rb:8:in `in_rtypes'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings/markdown/resource_types.rb:30:in `toc_info'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings/markdown/table_of_contents.rb:13:in `block in render'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings/markdown/table_of_contents.rb:12:in `each'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings/markdown/table_of_contents.rb:12:in `render'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings/markdown.rb:19:in `generate'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings/markdown.rb:38:in `block in render'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings/markdown.rb:38:in `open'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings/markdown.rb:38:in `render'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings.rb:81:in `render_markdown'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings.rb:62:in `generate'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings/tasks/generate.rb:43:in `block (2 levels) in <top (required)>'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/puppet-strings-2.5.0/lib/puppet-strings/tasks/generate.rb:49:in `block (3 levels) in <top (required)>'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/Rakefile:24:in `block in <top (required)>'
/home/bastelfreak/modulesync_config/modules/voxpupuli/puppet-splunk/.vendor/ruby/2.7.0/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/home/bastelfreak/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
/home/bastelfreak/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
/home/bastelfreak/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:28:in `run'
/home/bastelfreak/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/cli.rb:476:in `exec'
/home/bastelfreak/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/home/bastelfreak/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/home/bastelfreak/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
/home/bastelfreak/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/cli.rb:30:in `dispatch'
/home/bastelfreak/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
/home/bastelfreak/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/cli.rb:24:in `start'
/home/bastelfreak/.gem/ruby/2.7.0/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
/home/bastelfreak/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
/home/bastelfreak/.gem/ruby/2.7.0/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
/home/bastelfreak/.gem/ruby/2.7.0/bin/bundle:23:in `load'
/home/bastelfreak/.gem/ruby/2.7.0/bin/bundle:23:in `<main>'
Tasks: TOP => strings:generate
(See full trace by running task with --trace)
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
