### PR TITLE
add option to manage net-tools package

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -266,6 +266,18 @@ manage the Splunk Enterprise service.
 
 Default value: $splunk::params::boot_start
 
+##### `manage_net_tools`
+
+Data type: `Boolean`
+
+Whether or not to declare the resource Package[net-tools].
+
+The package `net-tools` is required by Splunk 7.2.2+ to be installed on the system.
+By default this module manages the resource Package[net-tools], if this resource is
+already declared on your code base, you can set this flag to `false`.
+
+Default value: $splunk::params::manage_net_tools
+
 ##### `use_default_config`
 
 Data type: `Boolean`
@@ -906,6 +918,18 @@ manage the Splunk Forwarder service.
 
 Default value: $splunk::params::boot_start
 
+##### `manage_net_tools`
+
+Data type: `Boolean`
+
+Whether or not to declare the resource Package[net-tools].
+
+The package `net-tools` is required by Splunk 7.2.2+ to be installed on the system.
+By default this module manages the resource Package[net-tools], if this resource is
+already declared on your code base, you can set this flag to `false`.
+
+Default value: $splunk::params::manage_net_tools
+
 ##### `use_default_config`
 
 Data type: `Boolean`
@@ -1424,6 +1448,18 @@ Enable Splunk to start at boot, create a system service file.
 
 WARNING: Toggling `boot_start` from `false` to `true` will cause a restart of
 Splunk Enterprise and Forwarder services.
+
+Default value: `true`
+
+##### `manage_net_tools`
+
+Data type: `Boolean`
+
+Whether or not to declare the resource Package[net-tools].
+
+The package `net-tools` is required by Splunk 7.2.2+ to be installed on the system.
+By default this module manages the resource Package[net-tools], if this resource is
+already declared on your code base, you can set this flag to `false`.
 
 Default value: `true`
 

--- a/manifests/enterprise/install/nix.pp
+++ b/manifests/enterprise/install/nix.pp
@@ -31,7 +31,7 @@ class splunk::enterprise::install::nix inherits splunk::enterprise::install {
   }
 
   # Required for splunk 7.2.4.2
-  if versioncmp($splunk::enterprise::version, '7.2.4.2') >= 0 {
+  if $splunk::params::manage_net_tools and versioncmp($splunk::enterprise::version, '7.2.4.2') >= 0 {
     ensure_packages(['net-tools'], {
         'ensure' => 'present',
     })

--- a/manifests/forwarder/install.pp
+++ b/manifests/forwarder/install.pp
@@ -61,7 +61,7 @@ class splunk::forwarder::install {
   }
 
   # Required for splunk 7.2.4.2
-  if ($facts['kernel'] == 'Linux' or $facts['kernel'] == 'SunOS') and (versioncmp($splunk::forwarder::version, '7.2.4.2') >= 0) {
+  if $splunk::params::manage_net_tools and ($facts['kernel'] == 'Linux' or $facts['kernel'] == 'SunOS') and (versioncmp($splunk::forwarder::version, '7.2.4.2') >= 0) {
     ensure_packages(['net-tools'], {
         'ensure' => 'present',
     })

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -92,6 +92,11 @@
 # @param default_host
 #   The host property in inputs.conf. Defaults to the server's hostname.
 #
+# @param manage_net_tools
+#   From Splunk 7.2.2+ the package `net-tools` is required to be installed on the system.
+#   By default this module manages the resource Package[net-tools], if this resource is
+#   already declared on your code base, you can disable this flag.
+#
 class splunk::params (
   String[1] $version                         = '7.2.4.2',
   String[1] $build                           = 'fb30470262e3',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -107,6 +107,7 @@ class splunk::params (
     default => 'root'
   },
   String[1] $default_host                    = $facts['clientcert'],
+  Boolean $manage_net_tools                  = true,
 ) {
   # Based on the small number of inputs above, we can construct sane defaults
   # for pretty much everything else.

--- a/spec/classes/enterprise_spec.rb
+++ b/spec/classes/enterprise_spec.rb
@@ -95,6 +95,25 @@ describe 'splunk::enterprise' do
                 it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
               end
 
+              context 'with $facts[service_provider] == init and $splunk::params::version >= 7.2.2 and manage_net_tools == false' do
+                let(:facts) do
+                  facts.merge(service_provider: 'init')
+                end
+                let(:pre_condition) do
+                  "class { 'splunk::params': version => '7.2.4.2', manage_net_tools => false }"
+                end
+
+                it_behaves_like 'splunk enterprise nix defaults'
+                it { is_expected.not_to contain_package('net-tools') }
+                it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'splunk') }
+                it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
+                it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop') }
+                it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
+                it { is_expected.not_to contain_exec('disable_splunk') }
+                it { is_expected.not_to contain_exec('license_splunk') }
+                it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
+              end
+
               context 'with $facts[service_provider] == init and $splunk::params::version < 7.2.2' do
                 let(:facts) do
                   facts.merge(service_provider: 'init')
@@ -114,6 +133,25 @@ describe 'splunk::enterprise' do
                 it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
               end
 
+              context 'with $facts[service_provider] == init and $splunk::params::version < 7.2.2 and manage_net_tools == false' do
+                let(:facts) do
+                  facts.merge(service_provider: 'init')
+                end
+                let(:pre_condition) do
+                  "class { 'splunk::params': version => '6.0.0', manage_net_tools => false }"
+                end
+
+                it_behaves_like 'splunk enterprise nix defaults'
+                it { is_expected.not_to contain_package('net-tools') }
+                it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'splunk') }
+                it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
+                it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop') }
+                it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
+                it { is_expected.not_to contain_exec('disable_splunk') }
+                it { is_expected.not_to contain_exec('license_splunk') }
+                it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
+              end
+
               context 'with $facts[service_provider] == systemd and $splunk::params::version >= 7.2.2' do
                 let(:facts) do
                   facts.merge(service_provider: 'systemd')
@@ -124,6 +162,25 @@ describe 'splunk::enterprise' do
 
                 it_behaves_like 'splunk enterprise nix defaults'
                 it { is_expected.to contain_package('net-tools').with(ensure: 'present') }
+                it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'Splunkd') }
+                it { is_expected.to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
+                it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop') }
+                it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start  -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
+                it { is_expected.not_to contain_exec('disable_splunk') }
+                it { is_expected.not_to contain_exec('license_splunk') }
+                it { is_expected.to contain_service('Splunkd').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
+              end
+
+              context 'with $facts[service_provider] == systemd and $splunk::params::version >= 7.2.2 and manage_net_tools == false' do
+                let(:facts) do
+                  facts.merge(service_provider: 'systemd')
+                end
+                let(:pre_condition) do
+                  "class { 'splunk::params': version => '7.2.4.2', manage_net_tools => false }"
+                end
+
+                it_behaves_like 'splunk enterprise nix defaults'
+                it { is_expected.not_to contain_package('net-tools') }
                 it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'Splunkd') }
                 it { is_expected.to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
                 it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop') }
@@ -164,6 +221,25 @@ describe 'splunk::enterprise' do
                 it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
               end
 
+              context 'with $facts[service_provider] == systemd and $splunk::params::version < 7.2.2 and manage_net_tools == false' do
+                let(:facts) do
+                  facts.merge(service_provider: 'systemd')
+                end
+                let(:pre_condition) do
+                  "class { 'splunk::params': version => '6.0.0', manage_net_tools => false }"
+                end
+
+                it_behaves_like 'splunk enterprise nix defaults'
+                it { is_expected.not_to contain_package('net-tools') }
+                it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'splunk') }
+                it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
+                it { is_expected.to contain_exec('stop_splunk').with(command: '/opt/splunk/bin/splunk stop') }
+                it { is_expected.to contain_exec('enable_splunk').with(command: '/opt/splunk/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
+                it { is_expected.not_to contain_exec('disable_splunk') }
+                it { is_expected.not_to contain_exec('license_splunk') }
+                it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
+              end
+
             end
           end
 
@@ -180,6 +256,25 @@ describe 'splunk::enterprise' do
 
                 it_behaves_like 'splunk enterprise nix defaults'
                 it { is_expected.to contain_package('net-tools').with(ensure: 'present') }
+                it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'splunk') }
+                it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
+                it { is_expected.not_to contain_exec('stop_splunk') }
+                it { is_expected.not_to contain_exec('enable_splunk') }
+                it { is_expected.to contain_exec('disable_splunk').with(command: '/opt/splunk/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('license_splunk').with(command: '/opt/splunk/bin/splunk start --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_service('splunk').with(restart: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk restart'", start: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk start'", stop: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk stop'", status: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk status'") }
+              end
+
+              context 'with $facts[service_provider] == init and $splunk::params::version >= 7.2.2 and manage_net_tools == false' do
+                let(:facts) do
+                  facts.merge(service_provider: 'init')
+                end
+                let(:pre_condition) do
+                  "class { 'splunk::params': version => '7.2.4.2', boot_start => false, manage_net_tools => false }"
+                end
+
+                it_behaves_like 'splunk enterprise nix defaults'
+                it { is_expected.not_to contain_package('net-tools') }
                 it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'splunk') }
                 it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
                 it { is_expected.not_to contain_exec('stop_splunk') }
@@ -208,6 +303,25 @@ describe 'splunk::enterprise' do
                 it { is_expected.to contain_service('splunk').with(restart: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk restart'", start: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk start'", stop: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk stop'", status: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk status'") }
               end
 
+              context 'with $facts[service_provider] == init and $splunk::params::version < 7.2.2 and manage_net_tools == false' do
+                let(:facts) do
+                  facts.merge(service_provider: 'init')
+                end
+                let(:pre_condition) do
+                  "class { 'splunk::params': version => '6.0.0', boot_start => false, manage_net_tools => false }"
+                end
+
+                it_behaves_like 'splunk enterprise nix defaults'
+                it { is_expected.not_to contain_package('net-tools') }
+                it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'splunk') }
+                it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
+                it { is_expected.not_to contain_exec('stop_splunk') }
+                it { is_expected.not_to contain_exec('enable_splunk') }
+                it { is_expected.to contain_exec('disable_splunk').with(command: '/opt/splunk/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('license_splunk').with(command: '/opt/splunk/bin/splunk start --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_service('splunk').with(restart: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk restart'", start: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk start'", stop: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk stop'", status: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk status'") }
+              end
+
               context 'with $facts[service_provider] == systemd and $splunk::params::version >= 7.2.2' do
                 let(:facts) do
                   facts.merge(service_provider: 'systemd')
@@ -227,6 +341,25 @@ describe 'splunk::enterprise' do
                 it { is_expected.to contain_service('Splunkd').with(restart: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk restart'", start: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk start'", stop: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk stop'", status: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk status'") }
               end
 
+              context 'with $facts[service_provider] == systemd and $splunk::params::version >= 7.2.2 and manage_net_tools == false' do
+                let(:facts) do
+                  facts.merge(service_provider: 'systemd')
+                end
+                let(:pre_condition) do
+                  "class { 'splunk::params': version => '7.2.4.2', boot_start => false, manage_net_tools => false }"
+                end
+
+                it_behaves_like 'splunk enterprise nix defaults'
+                it { is_expected.not_to contain_package('net-tools') }
+                it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'Splunkd') }
+                it { is_expected.to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
+                it { is_expected.not_to contain_exec('stop_splunk') }
+                it { is_expected.not_to contain_exec('enable_splunk') }
+                it { is_expected.to contain_exec('disable_splunk').with(command: '/opt/splunk/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('license_splunk').with(command: '/opt/splunk/bin/splunk start --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_service('Splunkd').with(restart: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk restart'", start: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk start'", stop: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk stop'", status: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk status'") }
+              end
+
               context 'with $facts[service_provider] == systemd and $splunk::params::version < 7.2.2' do
                 let(:facts) do
                   facts.merge(service_provider: 'systemd')
@@ -237,6 +370,25 @@ describe 'splunk::enterprise' do
 
                 it_behaves_like 'splunk enterprise nix defaults'
                 it { is_expected.not_to contain_package('net-tools').with(ensure: 'present') }
+                it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'splunk') }
+                it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
+                it { is_expected.not_to contain_exec('stop_splunk') }
+                it { is_expected.not_to contain_exec('enable_splunk') }
+                it { is_expected.to contain_exec('disable_splunk').with(command: '/opt/splunk/bin/splunk disable boot-start -user root --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('license_splunk').with(command: '/opt/splunk/bin/splunk start --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_service('splunk').with(restart: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk restart'", start: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk start'", stop: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk stop'", status: "/usr/sbin/runuser -l root -c '/opt/splunk/bin/splunk status'") }
+              end
+
+              context 'with $facts[service_provider] == systemd and $splunk::params::version < 7.2.2 and manage_net_tools == false' do
+                let(:facts) do
+                  facts.merge(service_provider: 'systemd')
+                end
+                let(:pre_condition) do
+                  "class { 'splunk::params': version => '6.0.0', boot_start => false, manage_net_tools => false }"
+                end
+
+                it_behaves_like 'splunk enterprise nix defaults'
+                it { is_expected.not_to contain_package('net-tools') }
                 it { is_expected.to contain_class('splunk::enterprise').with(service_name: 'splunk') }
                 it { is_expected.not_to contain_file('/etc/init.d/splunk').with(ensure: 'absent') }
                 it { is_expected.not_to contain_exec('stop_splunk') }


### PR DESCRIPTION
I believe this is a controversial pull request.

net-tools is very common dependency, and in a huge code base with many dependencies most likely it will be already declared somewhere.

I've introduced a flag `manage_net_tools` in params.pp with a default `true`, which will keep working as it is for everyone, but will allow projects like ours to mark it as `false` when net-tools is already managed somewhere else.

Thanks.

Manuel