### PR TITLE
Drop CentOS 6 support

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,7 +2,6 @@
 .travis.yml:
   secure: "RrAmWtM6eTjZZzD954AIgR179Pqp14lzHhd/C9cpKbTPynLncuim08CEvjmq+7pgAy9XDg1d02x3udfZt4btR1sBdyNRpNN3yUhWptmGU61HRJdiZq+nSLQkIYsqXanhk+O3NndFojO58WRD01dkWEc6HRHjlivuYNxDXmMkg9k="
   docker_sets:
-  - set: centos6-64
   - set: centos7-64
   - set: debian8-64
   - set: ubuntu1604-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,6 @@ jobs:
       env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
     - rvm: 2.5.3
       bundler_args: --without development release
-      env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos6-64 CHECK=beaker
-      services: docker
-    - rvm: 2.5.3
-      bundler_args: --without development release
-      env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=centos6-64 CHECK=beaker
-      services: docker
-    - rvm: 2.5.3
-      bundler_args: --without development release
       env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos7-64 CHECK=beaker
       services: docker
     - rvm: 2.5.3

--- a/metadata.json
+++ b/metadata.json
@@ -11,14 +11,12 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },


### PR DESCRIPTION
CentOS 6 is EOL. The CentOS people also removed their stuff from the
mirrors so our acceptance tests do not pass anymore.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
