### PR TITLE
splunk_metadata - is_global? -> global?

### DIFF
--- a/lib/puppet/provider/splunk_metadata/ini_setting.rb
+++ b/lib/puppet/provider/splunk_metadata/ini_setting.rb
@@ -8,7 +8,7 @@ class SectionNoGlobal < Puppet::Util::IniFile::Section
   end
 
   # this section is never global, allowing for sections with an empty name ([])
-  def is_global? # rubocop:disable Style/PredicateName
+  def global? # rubocop:disable Style/PredicateName
     false
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
The function "is_global?" should be named "global?".

Reference: https://github.com/puppetlabs/puppetlabs-inifile/blob/main/lib/puppet/util/ini_file/section.rb#L28-L30

#### This Pull Request (PR) fixes the following issues
n/a
