### PR TITLE
Drop Puppet 5, add Puppet 7 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -72,7 +72,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
#### Pull Request (PR) description

Puppet 5 has reached EOL, update metadata.json.

#307 added support for Ubuntu 20.04 for which no Puppet 5 package is available.  Dropping support for Puppet 5 should allow the test suite to be green again

#### This Pull Request (PR) fixes the following issues
n/a