### PR TITLE
Add extract_command as a parameter to splunk::addon

### DIFF
--- a/manifests/addon.pp
+++ b/manifests/addon.pp
@@ -31,6 +31,9 @@
 # @param splunkbase_source
 #   When set the add-on will be installed from a splunkbase compatible archive instead of OS packages
 #
+# @param extract_command
+#   A 'extract_command' to pass to the 'archive' that extracts a splunkbase_source package (helpful for SPL files)
+#
 # @param package_name
 #  The OS package to install if you are not installing via splunk compatible archive
 #
@@ -44,6 +47,7 @@ define splunk::addon (
   Optional[Stdlib::Absolutepath] $splunk_home = undef,
   Boolean $package_manage                     = true,
   Optional[String[1]] $splunkbase_source      = undef,
+  Optional[String[1]] $extract_command        = undef,
   Optional[String[1]] $package_name           = undef,
   String[1] $owner                            = 'splunk',
   Hash $inputs                                = {},
@@ -70,15 +74,16 @@ define splunk::addon (
     if $splunkbase_source {
       $archive_name = $splunkbase_source.split('/')[-1]
       archive { $name:
-        path         => "${splunk::params::staging_dir}/${archive_name}",
-        user         => $owner,
-        group        => $owner,
-        source       => $splunkbase_source,
-        extract      => true,
-        extract_path => "${_splunk_home}/etc/apps",
-        creates      => "${_splunk_home}/etc/apps/${name}",
-        cleanup      => true,
-        before       => File["${_splunk_home}/etc/apps/${name}/local"],
+        path            => "${splunk::params::staging_dir}/${archive_name}",
+        user            => $owner,
+        group           => $owner,
+        source          => $splunkbase_source,
+        extract         => true,
+        extract_path    => "${_splunk_home}/etc/apps",
+        extract_command => $extract_command,
+        creates         => "${_splunk_home}/etc/apps/${name}",
+        cleanup         => true,
+        before          => File["${_splunk_home}/etc/apps/${name}/local"],
       }
     } else {
       package { $package_name:

--- a/spec/defines/addon_spec.rb
+++ b/spec/defines/addon_spec.rb
@@ -43,11 +43,13 @@ describe 'splunk::addon' do
 
           context 'addon requiring extract_command' do
             let(:title) { 'Splunk_TA' }
-            let(:params) { { 'splunkbase_source' => 'puppet:///modules/profiles/splunk-add-on.spl',
-                             'extract_command' => 'tar zxf %s', } }
+            let(:params) do
+              { 'splunkbase_source' => 'puppet:///modules/profiles/splunk-add-on.spl',
+                'extract_command' => 'tar zxf %s' }
+            end
 
             it { is_expected.to compile.with_all_deps }
-            it { is_expected.to contain_archive('Splunk_TA').with(source: 'puppet:///modules/profiles/splunk-add-on.spl', extract_command: 'tar zxf %s', ) }
+            it { is_expected.to contain_archive('Splunk_TA').with(source: 'puppet:///modules/profiles/splunk-add-on.spl', extract_command: 'tar zxf %s') }
           end
         end
       end

--- a/spec/defines/addon_spec.rb
+++ b/spec/defines/addon_spec.rb
@@ -32,10 +32,23 @@ describe 'splunk::addon' do
           let(:facts) do
             facts
           end
-          let(:title) { 'Splunk_TA' }
-          let(:params) { { 'splunkbase_source' => 'puppet:///modules/profiles/splunk-add-on.tgz' } }
 
-          it { is_expected.to compile.with_all_deps }
+          context 'basic addon' do
+            let(:title) { 'Splunk_TA' }
+            let(:params) { { 'splunkbase_source' => 'puppet:///modules/profiles/splunk-add-on.tgz' } }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_archive('Splunk_TA').with(source: 'puppet:///modules/profiles/splunk-add-on.tgz') }
+          end
+
+          context 'addon requiring extract_command' do
+            let(:title) { 'Splunk_TA' }
+            let(:params) { { 'splunkbase_source' => 'puppet:///modules/profiles/splunk-add-on.spl',
+                             'extract_command' => 'tar zxf %s', } }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_archive('Splunk_TA').with(source: 'puppet:///modules/profiles/splunk-add-on.spl', extract_command: 'tar zxf %s', ) }
+          end
         end
       end
     end


### PR DESCRIPTION
#### Pull Request (PR) description
Add `extract_command` as a parameter to `splunk::addon`

#### This Pull Request (PR) fixes the following issues
https://dev.splunk.com/enterprise/docs/releaseapps/packageapps/ - "An app package is a compressed tar archive, or tarball, with a .spl, .tgz, or .tar.gz file extension"
The `archive` module (which this module calls) does not know what a `.spl` file is, and will refuse to untar it.  But it's simply a tarball.

`.spl`, as an extension, is not unique to Splunk (it means 'spool' in some contexts) so it's probably not smart to edit the `archive` module to 'know' about `.spl`, just to satisfy one vendor.

This commit is intended to allow you to keep a `.spl`-named source file, and for puppet know what to do with it.

The alternate to rename the file to `.tgz` is possible, but somewhat non-obvious for users, who may want to keep their spl filename.

It would be possible to put some logic in `splunk::addon` to detect a .spl source via regexp and pass along some 'tar zxf %s' `extract_command`, but because of OS variations I think it's best not to gum up the works with a Linux bias and to leave the work up to a profile that uses the `splunk` module.