### PR TITLE
Allow user-seed.conf to set a username besides 'admin'

### DIFF
--- a/manifests/enterprise.pp
+++ b/manifests/enterprise.pp
@@ -156,6 +156,9 @@
 #   Which file to place the admin password hash in so its imported by Splunk on
 #   restart.
 #
+# @param seed_user
+#   The local user (usually 'admin') imported by Splunk.
+#
 # @param password_content
 #   The hashed password username/details for the user.
 #
@@ -214,6 +217,7 @@ class splunk::enterprise (
   Stdlib::Absolutepath $seed_config_file     = $splunk::params::enterprise_seed_config_file,
   String[1] $password_content                = $splunk::params::password_content,
   String[1] $password_hash                   = $splunk::params::password_hash,
+  String[1] $seed_user                       = $splunk::params::seed_user,
   Stdlib::Absolutepath $secret_file          = $splunk::params::enterprise_secret_file,
   String[1] $secret                          = $splunk::params::secret,
 ) inherits splunk {

--- a/manifests/enterprise/config.pp
+++ b/manifests/enterprise/config.pp
@@ -8,6 +8,7 @@ class splunk::enterprise::config () {
       reset_seeded_password => $splunk::enterprise::reset_seeded_password,
       password_config_file  => $splunk::enterprise::password_config_file,
       seed_config_file      => $splunk::enterprise::seed_config_file,
+      seed_user             => $splunk::enterprise::seed_user,
       password_hash         => $splunk::enterprise::password_hash,
       secret_file           => $splunk::enterprise::secret_file,
       secret                => $splunk::enterprise::secret,

--- a/manifests/enterprise/password/seed.pp
+++ b/manifests/enterprise/password/seed.pp
@@ -15,6 +15,9 @@
 #   Which file to place the admin password hash in so its imported by Splunk on
 #   restart.
 #
+# @param seed_user
+#   The local user (usually 'admin') imported by Splunk.
+#
 # @param password_hash
 #   The hashed password for the admin user.
 #
@@ -39,6 +42,7 @@ class splunk::enterprise::password::seed (
   Boolean $reset_seeded_password             = $splunk::params::reset_seeded_password,
   Stdlib::Absolutepath $password_config_file = $splunk::params::enterprise_password_config_file,
   Stdlib::Absolutepath $seed_config_file     = $splunk::params::enterprise_seed_config_file,
+  String[1] $seed_user                       = $splunk::params::seed_user,
   String[1] $password_hash                   = $splunk::params::password_hash,
   Stdlib::Absolutepath $secret_file          = $splunk::params::enterprise_secret_file,
   String[1] $secret                          = $splunk::params::secret,
@@ -62,7 +66,7 @@ class splunk::enterprise::password::seed (
       ensure  => file,
       owner   => $splunk_user,
       group   => $splunk_user,
-      content => epp('splunk/user-seed.conf.epp', { 'hash' => $password_hash }),
+      content => epp('splunk/user-seed.conf.epp', { 'user' => $seed_user, 'hash' => $password_hash }),
       require => File[$secret_file],
     }
 

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -132,6 +132,9 @@
 #   Which file to place the admin password hash in so its imported by Splunk on
 #   restart.
 #
+# @param seed_user
+#   The local user (usually 'admin') imported by Splunk.
+#
 # @param password_content
 #   The hashed password username/details for the user.
 #
@@ -184,6 +187,7 @@ class splunk::forwarder (
   Stdlib::Absolutepath $seed_config_file     = $splunk::params::forwarder_seed_config_file,
   String[1] $password_content                = $splunk::params::password_content,
   String[1] $password_hash                   = $splunk::params::password_hash,
+  String[1] $seed_user                       = $splunk::params::seed_user,
   Stdlib::Absolutepath $secret_file          = $splunk::params::forwarder_secret_file,
   String[1] $secret                          = $splunk::params::secret,
   Hash $addons                               = {},

--- a/manifests/forwarder/config.pp
+++ b/manifests/forwarder/config.pp
@@ -9,6 +9,7 @@ class splunk::forwarder::config {
       reset_seeded_password => $splunk::forwarder::reset_seeded_password,
       password_config_file  => $splunk::forwarder::password_config_file,
       seed_config_file      => $splunk::forwarder::seed_config_file,
+      seed_user             => $splunk::forwarder::seed_user,
       password_hash         => $splunk::forwarder::password_hash,
       secret_file           => $splunk::forwarder::secret_file,
       secret                => $splunk::forwarder::secret,

--- a/manifests/forwarder/password/seed.pp
+++ b/manifests/forwarder/password/seed.pp
@@ -15,6 +15,9 @@
 #   Which file to place the admin password hash in so its imported by Splunk on
 #   restart.
 #
+# @param seed_user
+#   The local user (usually 'admin') imported by Splunk.
+#
 # @param password_hash
 #   The hashed password for the admin user.
 #
@@ -39,6 +42,7 @@ class splunk::forwarder::password::seed (
   Boolean $reset_seeded_password             = $splunk::params::reset_seeded_password,
   Stdlib::Absolutepath $password_config_file = $splunk::params::forwarder_password_config_file,
   Stdlib::Absolutepath $seed_config_file     = $splunk::params::forwarder_seed_config_file,
+  String[1] $seed_user                       = $splunk::params::seed_user,
   String[1] $password_hash                   = $splunk::params::password_hash,
   Stdlib::Absolutepath $secret_file          = $splunk::params::forwarder_secret_file,
   String[1] $secret                          = $splunk::params::secret,
@@ -62,7 +66,7 @@ class splunk::forwarder::password::seed (
       ensure  => file,
       owner   => $splunk_user,
       group   => $splunk_user,
-      content => epp('splunk/user-seed.conf.epp', { 'hash' => $password_hash }),
+      content => epp('splunk/user-seed.conf.epp', { 'user' => $seed_user, 'hash' => $password_hash }),
       require => File[$secret_file],
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -125,6 +125,7 @@ class splunk::params (
   $seed_password         = false
   $reset_seeded_password = false
   $secret                = 'hhy9DOGqli4.aZWCuGvz8stcqT2/OSJUZuyWHKc4wnJtQ6IZu2bfjeElgYmGHN9RWIT3zs5hRJcX1wGerpMNObWhFue78jZMALs3c3Mzc6CzM98/yGYdfcvWMo1HRdKn82LVeBJI5dNznlZWfzg6xdywWbeUVQZcOZtODi10hdxSJ4I3wmCv0nmkSWMVOEKHxti6QLgjfuj/MOoh8.2pM0/CqF5u6ORAzqFZ8Qf3c27uVEahy7ShxSv2K4K41z'
+  $seed_user             = 'admin'
   $password_hash         = '$6$pIE/xAyP9mvBaewv$4GYFxC0SqonT6/x8qGcZXVCRLUVKODj9drDjdu/JJQ/Iw0Gg.aTkFzCjNAbaK4zcCHbphFz1g1HK18Z2bI92M0'
   $password_content      = ":admin:${password_hash}::Administrator:admin:changeme@example.com::"
 

--- a/spec/acceptance/splunk_enterprise_spec.rb
+++ b/spec/acceptance/splunk_enterprise_spec.rb
@@ -58,6 +58,7 @@ describe 'splunk enterprise class' do
         pp = <<-EOS
         class { 'splunk::enterprise':
           seed_password         => true,
+          seed_user             => 's0me0ne',
           password_hash         => '$6$not4r3alh45h',
         }
         EOS
@@ -69,6 +70,7 @@ describe 'splunk enterprise class' do
 
       describe file('/opt/splunk/etc/passwd') do
         it { is_expected.to be_file }
+        its(:content) { is_expected.to match %r{s0me0ne} }
         its(:content) { is_expected.to match %r{\$6\$not4r3alh45h} }
       end
     end

--- a/spec/acceptance/splunk_enterprise_spec.rb
+++ b/spec/acceptance/splunk_enterprise_spec.rb
@@ -58,7 +58,6 @@ describe 'splunk enterprise class' do
         pp = <<-EOS
         class { 'splunk::enterprise':
           seed_password         => true,
-          seed_user             => 's0me0ne',
           password_hash         => '$6$not4r3alh45h',
         }
         EOS
@@ -70,7 +69,6 @@ describe 'splunk enterprise class' do
 
       describe file('/opt/splunk/etc/passwd') do
         it { is_expected.to be_file }
-        its(:content) { is_expected.to match %r{s0me0ne} }
         its(:content) { is_expected.to match %r{\$6\$not4r3alh45h} }
       end
     end

--- a/spec/classes/enterprise/password/seed_spec.rb
+++ b/spec/classes/enterprise/password/seed_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'splunk::enterprise::password::seed' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        if os.start_with?('windows')
+          # Splunk Server not used supported on windows
+        else
+
+          context 'when passed no parameters' do
+            let(:facts) { facts }
+            it { is_expected.to compile.with_all_deps }
+          end
+
+          context 'managing a secret file' do
+            let(:facts) { facts }
+            let(:params) do
+              { 'secret_file' => '/some/secretfilepath',
+                'splunk_user' => 'someuser',
+                'secret'      => 'hunter2',
+              }
+            end
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_file('/some/secretfilepath').with(ensure: 'file', owner: 'someuser', group: 'someuser', content: 'hunter2') }
+            # That owner/group thing is kinda awful.  Someone who cares should fix that.
+          end
+
+          context 'do not maintain seed_config_file if we are not resetting' do
+            # splunk_version fact means we installed previously
+            let(:facts) do
+              facts.merge( { 'splunk_version' => '1.2.3' } )
+            end
+            let(:params) do
+              { 'seed_config_file'      => '/some/seedfile1',
+                'reset_seeded_password' => false,
+              }
+            end
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.not_to contain_file('/some/seedfile1') }
+          end
+
+          context 'do maintain seed_config_file if we are told to reset' do
+            let(:facts) do
+              facts.merge( { 'splunk_version' => '1.2.3' } )
+            end
+            let(:params) do
+              { 'reset_seeded_password' => true,
+                'password_config_file'  => '/some/conffile',
+                'seed_config_file'      => '/some/seedfile',
+                'seed_user'             => 'adminuser',
+                'password_hash'         => 'abcdefghijklmnop',
+                'splunk_user'           => 'someuser',
+                'service'               => 'theforwarderservice',
+                'mode'                  => 'agent',
+              }
+            end
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_file('/some/conffile').with(ensure: 'absent') }
+            it { is_expected.to contain_file('/some/seedfile').with(ensure: 'file', owner: 'someuser', group: 'someuser') }
+            it { is_expected.to contain_file('/some/seedfile').with_content(%r{USERNAME=adminuser}) }
+            it { is_expected.to contain_file('/some/seedfile').with_content(%r{HASHED_PASSWORD=abcdefghijklmnop}) }
+            it { is_expected.not_to contain_service('theforwarderservice') }
+          end
+
+          context 'do maintain seed_config_file if we are installing via agent' do
+            # no splunk_version fact and reset_seeded_password=false is 'installing'
+            let(:facts) { facts }
+            let(:params) do
+              { 'reset_seeded_password' => false,
+                'password_config_file'  => '/some/conffile',
+                'seed_config_file'      => '/some/seedfile',
+                'seed_user'             => 'adminuser',
+                'password_hash'         => 'abcdefghijklmnop',
+                'splunk_user'           => 'someuser',
+                'service'               => 'theforwarderservice',
+                'mode'                  => 'agent',
+              }
+            end
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_file('/some/conffile').with(ensure: 'absent') }
+            it { is_expected.to contain_file('/some/seedfile').with(ensure: 'file', owner: 'someuser', group: 'someuser') }
+            it { is_expected.to contain_file('/some/seedfile').with_content(%r{USERNAME=adminuser}) }
+            it { is_expected.to contain_file('/some/seedfile').with_content(%r{HASHED_PASSWORD=abcdefghijklmnop}) }
+            it { is_expected.not_to contain_service('theforwarderservice') }
+          end
+
+          context 'do maintain seed_config_file if we are installing via bolt' do
+            # no splunk_version fact and reset_seeded_password=false is 'installing'
+            let(:facts) { facts }
+            let(:params) do
+              { 'reset_seeded_password' => false,
+                'password_config_file'  => '/some/conffile',
+                'seed_config_file'      => '/some/seedfile',
+                'seed_user'             => 'adminuser',
+                'password_hash'         => 'abcdefghijklmnop',
+                'splunk_user'           => 'someuser',
+                'service'               => 'theforwarderservice',
+                'mode'                  => 'bolt',
+              }
+            end
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_file('/some/conffile').with(ensure: 'absent') }
+            it { is_expected.to contain_file('/some/seedfile').with(ensure: 'file', owner: 'someuser', group: 'someuser') }
+            it { is_expected.to contain_file('/some/seedfile').with_content(%r{USERNAME=adminuser}) }
+            it { is_expected.to contain_file('/some/seedfile').with_content(%r{HASHED_PASSWORD=abcdefghijklmnop}) }
+            it { is_expected.to contain_service('theforwarderservice').with(ensure: 'running', enable: true) }
+          end
+
+        end
+      end
+    end
+  end
+end
+

--- a/spec/classes/enterprise/password/seed_spec.rb
+++ b/spec/classes/enterprise/password/seed_spec.rb
@@ -12,6 +12,7 @@ describe 'splunk::enterprise::password::seed' do
 
           context 'when passed no parameters' do
             let(:facts) { facts }
+
             it { is_expected.to compile.with_all_deps }
           end
 
@@ -20,9 +21,9 @@ describe 'splunk::enterprise::password::seed' do
             let(:params) do
               { 'secret_file' => '/some/secretfilepath',
                 'splunk_user' => 'someuser',
-                'secret'      => 'hunter2',
-              }
+                'secret'      => 'hunter2', }
             end
+
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_file('/some/secretfilepath').with(ensure: 'file', owner: 'someuser', group: 'someuser', content: 'hunter2') }
             # That owner/group thing is kinda awful.  Someone who cares should fix that.
@@ -31,20 +32,20 @@ describe 'splunk::enterprise::password::seed' do
           context 'do not maintain seed_config_file if we are not resetting' do
             # splunk_version fact means we installed previously
             let(:facts) do
-              facts.merge( { 'splunk_version' => '1.2.3' } )
+              facts.merge({ 'splunk_version' => '1.2.3' })
             end
             let(:params) do
               { 'seed_config_file'      => '/some/seedfile1',
-                'reset_seeded_password' => false,
-              }
+                'reset_seeded_password' => false, }
             end
+
             it { is_expected.to compile.with_all_deps }
             it { is_expected.not_to contain_file('/some/seedfile1') }
           end
 
           context 'do maintain seed_config_file if we are told to reset' do
             let(:facts) do
-              facts.merge( { 'splunk_version' => '1.2.3' } )
+              facts.merge({ 'splunk_version' => '1.2.3' })
             end
             let(:params) do
               { 'reset_seeded_password' => true,
@@ -54,9 +55,9 @@ describe 'splunk::enterprise::password::seed' do
                 'password_hash'         => 'abcdefghijklmnop',
                 'splunk_user'           => 'someuser',
                 'service'               => 'theforwarderservice',
-                'mode'                  => 'agent',
-              }
+                'mode'                  => 'agent', }
             end
+
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_file('/some/conffile').with(ensure: 'absent') }
             it { is_expected.to contain_file('/some/seedfile').with(ensure: 'file', owner: 'someuser', group: 'someuser') }
@@ -76,9 +77,9 @@ describe 'splunk::enterprise::password::seed' do
                 'password_hash'         => 'abcdefghijklmnop',
                 'splunk_user'           => 'someuser',
                 'service'               => 'theforwarderservice',
-                'mode'                  => 'agent',
-              }
+                'mode'                  => 'agent', }
             end
+
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_file('/some/conffile').with(ensure: 'absent') }
             it { is_expected.to contain_file('/some/seedfile').with(ensure: 'file', owner: 'someuser', group: 'someuser') }
@@ -98,9 +99,9 @@ describe 'splunk::enterprise::password::seed' do
                 'password_hash'         => 'abcdefghijklmnop',
                 'splunk_user'           => 'someuser',
                 'service'               => 'theforwarderservice',
-                'mode'                  => 'bolt',
-              }
+                'mode'                  => 'bolt', }
             end
+
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_file('/some/conffile').with(ensure: 'absent') }
             it { is_expected.to contain_file('/some/seedfile').with(ensure: 'file', owner: 'someuser', group: 'someuser') }
@@ -114,4 +115,3 @@ describe 'splunk::enterprise::password::seed' do
     end
   end
 end
-

--- a/spec/classes/forwarder/password/seed_spec.rb
+++ b/spec/classes/forwarder/password/seed_spec.rb
@@ -12,6 +12,7 @@ describe 'splunk::forwarder::password::seed' do
 
           context 'when passed no parameters' do
             let(:facts) { facts }
+
             it { is_expected.to compile.with_all_deps }
           end
 
@@ -20,9 +21,9 @@ describe 'splunk::forwarder::password::seed' do
             let(:params) do
               { 'secret_file' => '/some/secretfilepath',
                 'splunk_user' => 'someuser',
-                'secret'      => 'hunter2',
-              }
+                'secret'      => 'hunter2', }
             end
+
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_file('/some/secretfilepath').with(ensure: 'file', owner: 'someuser', group: 'someuser', content: 'hunter2') }
             # That owner/group thing is kinda awful.  Someone who cares should fix that.
@@ -31,20 +32,20 @@ describe 'splunk::forwarder::password::seed' do
           context 'do not maintain seed_config_file if we are not resetting' do
             # splunkforwarder_version fact means we installed previously
             let(:facts) do
-              facts.merge( { 'splunkforwarder_version' => '1.2.3' } )
+              facts.merge({ 'splunkforwarder_version' => '1.2.3' })
             end
             let(:params) do
               { 'seed_config_file'      => '/some/seedfile1',
-                'reset_seeded_password' => false,
-              }
+                'reset_seeded_password' => false, }
             end
+
             it { is_expected.to compile.with_all_deps }
             it { is_expected.not_to contain_file('/some/seedfile1') }
           end
 
           context 'do maintain seed_config_file if we are told to reset' do
             let(:facts) do
-              facts.merge( { 'splunkforwarder_version' => '1.2.3' } )
+              facts.merge({ 'splunkforwarder_version' => '1.2.3' })
             end
             let(:params) do
               { 'reset_seeded_password' => true,
@@ -54,9 +55,9 @@ describe 'splunk::forwarder::password::seed' do
                 'password_hash'         => 'abcdefghijklmnop',
                 'splunk_user'           => 'someuser',
                 'service'               => 'theforwarderservice',
-                'mode'                  => 'agent',
-              }
+                'mode'                  => 'agent', }
             end
+
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_file('/some/conffile').with(ensure: 'absent') }
             it { is_expected.to contain_file('/some/seedfile').with(ensure: 'file', owner: 'someuser', group: 'someuser') }
@@ -76,9 +77,9 @@ describe 'splunk::forwarder::password::seed' do
                 'password_hash'         => 'abcdefghijklmnop',
                 'splunk_user'           => 'someuser',
                 'service'               => 'theforwarderservice',
-                'mode'                  => 'agent',
-              }
+                'mode'                  => 'agent', }
             end
+
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_file('/some/conffile').with(ensure: 'absent') }
             it { is_expected.to contain_file('/some/seedfile').with(ensure: 'file', owner: 'someuser', group: 'someuser') }
@@ -98,9 +99,9 @@ describe 'splunk::forwarder::password::seed' do
                 'password_hash'         => 'abcdefghijklmnop',
                 'splunk_user'           => 'someuser',
                 'service'               => 'theforwarderservice',
-                'mode'                  => 'bolt',
-              }
+                'mode'                  => 'bolt', }
             end
+
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_file('/some/conffile').with(ensure: 'absent') }
             it { is_expected.to contain_file('/some/seedfile').with(ensure: 'file', owner: 'someuser', group: 'someuser') }

--- a/spec/classes/forwarder/password/seed_spec.rb
+++ b/spec/classes/forwarder/password/seed_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'splunk::forwarder::password::seed' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        if os.start_with?('windows')
+          # Splunk Server not used supported on windows
+        else
+
+          context 'when passed no parameters' do
+            let(:facts) { facts }
+            it { is_expected.to compile.with_all_deps }
+          end
+
+          context 'managing a secret file' do
+            let(:facts) { facts }
+            let(:params) do
+              { 'secret_file' => '/some/secretfilepath',
+                'splunk_user' => 'someuser',
+                'secret'      => 'hunter2',
+              }
+            end
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_file('/some/secretfilepath').with(ensure: 'file', owner: 'someuser', group: 'someuser', content: 'hunter2') }
+            # That owner/group thing is kinda awful.  Someone who cares should fix that.
+          end
+
+          context 'do not maintain seed_config_file if we are not resetting' do
+            # splunkforwarder_version fact means we installed previously
+            let(:facts) do
+              facts.merge( { 'splunkforwarder_version' => '1.2.3' } )
+            end
+            let(:params) do
+              { 'seed_config_file'      => '/some/seedfile1',
+                'reset_seeded_password' => false,
+              }
+            end
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.not_to contain_file('/some/seedfile1') }
+          end
+
+          context 'do maintain seed_config_file if we are told to reset' do
+            let(:facts) do
+              facts.merge( { 'splunkforwarder_version' => '1.2.3' } )
+            end
+            let(:params) do
+              { 'reset_seeded_password' => true,
+                'password_config_file'  => '/some/conffile',
+                'seed_config_file'      => '/some/seedfile',
+                'seed_user'             => 'adminuser',
+                'password_hash'         => 'abcdefghijklmnop',
+                'splunk_user'           => 'someuser',
+                'service'               => 'theforwarderservice',
+                'mode'                  => 'agent',
+              }
+            end
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_file('/some/conffile').with(ensure: 'absent') }
+            it { is_expected.to contain_file('/some/seedfile').with(ensure: 'file', owner: 'someuser', group: 'someuser') }
+            it { is_expected.to contain_file('/some/seedfile').with_content(%r{USERNAME=adminuser}) }
+            it { is_expected.to contain_file('/some/seedfile').with_content(%r{HASHED_PASSWORD=abcdefghijklmnop}) }
+            it { is_expected.not_to contain_service('theforwarderservice') }
+          end
+
+          context 'do maintain seed_config_file if we are installing via agent' do
+            # no splunkforwarder_version fact and reset_seeded_password=false is 'installing'
+            let(:facts) { facts }
+            let(:params) do
+              { 'reset_seeded_password' => false,
+                'password_config_file'  => '/some/conffile',
+                'seed_config_file'      => '/some/seedfile',
+                'seed_user'             => 'adminuser',
+                'password_hash'         => 'abcdefghijklmnop',
+                'splunk_user'           => 'someuser',
+                'service'               => 'theforwarderservice',
+                'mode'                  => 'agent',
+              }
+            end
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_file('/some/conffile').with(ensure: 'absent') }
+            it { is_expected.to contain_file('/some/seedfile').with(ensure: 'file', owner: 'someuser', group: 'someuser') }
+            it { is_expected.to contain_file('/some/seedfile').with_content(%r{USERNAME=adminuser}) }
+            it { is_expected.to contain_file('/some/seedfile').with_content(%r{HASHED_PASSWORD=abcdefghijklmnop}) }
+            it { is_expected.not_to contain_service('theforwarderservice') }
+          end
+
+          context 'do maintain seed_config_file if we are installing via bolt' do
+            # no splunkforwarder_version fact and reset_seeded_password=false is 'installing'
+            let(:facts) { facts }
+            let(:params) do
+              { 'reset_seeded_password' => false,
+                'password_config_file'  => '/some/conffile',
+                'seed_config_file'      => '/some/seedfile',
+                'seed_user'             => 'adminuser',
+                'password_hash'         => 'abcdefghijklmnop',
+                'splunk_user'           => 'someuser',
+                'service'               => 'theforwarderservice',
+                'mode'                  => 'bolt',
+              }
+            end
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_file('/some/conffile').with(ensure: 'absent') }
+            it { is_expected.to contain_file('/some/seedfile').with(ensure: 'file', owner: 'someuser', group: 'someuser') }
+            it { is_expected.to contain_file('/some/seedfile').with_content(%r{USERNAME=adminuser}) }
+            it { is_expected.to contain_file('/some/seedfile').with_content(%r{HASHED_PASSWORD=abcdefghijklmnop}) }
+            it { is_expected.to contain_service('theforwarderservice').with(ensure: 'running', enable: true) }
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/templates/user-seed.conf.epp
+++ b/templates/user-seed.conf.epp
@@ -1,4 +1,5 @@
-<%- | String $hash | -%>
+<%- | String $user,
+      String $hash | -%>
 [user_info]
-USERNAME=admin
+USERNAME=<%= $user %>
 HASHED_PASSWORD=<%= $hash %>


### PR DESCRIPTION
#### Pull Request (PR) description
Allow `user-seed.conf` to have a not-hardcoded userid instead of 'admin.

#### This Pull Request (PR) fixes the following issues
The `user-seed.conf` file sets a default local user/password (admin/changeme by default).  Some security policies wish for you to have only non-default userids.  At present, the existing module doesn't allow that.

The testing is a little lax here because there was not great testing on these classes to begin with.  Sorry.