### PR TITLE
Add support for using a proxy to install Splunk

### DIFF
--- a/manifests/enterprise.pp
+++ b/manifests/enterprise.pp
@@ -171,6 +171,12 @@
 # @param secret
 #   The secret used to salt the splunk password.
 #
+# @param install_proxy
+#   Proxy used to install Splunk enterprise package.
+#
+# @param install_proxy_type
+#   Proxy type used to install Splunk enterprise package.
+#
 class splunk::enterprise (
   String[1] $version                         = $splunk::params::version,
   String[1] $package_name                    = $splunk::params::enterprise_package_name,
@@ -220,6 +226,8 @@ class splunk::enterprise (
   String[1] $seed_user                       = $splunk::params::seed_user,
   Stdlib::Absolutepath $secret_file          = $splunk::params::enterprise_secret_file,
   String[1] $secret                          = $splunk::params::secret,
+  String[1] $install_proxy                   = $splunk::params::install_proxy,
+  String[1] $install_proxy_type              = $splunk::params::install_proxy_type,
 ) inherits splunk {
   if (defined(Class['splunk::forwarder'])) {
     fail('Splunk Universal Forwarder provides a subset of Splunk Enterprise capabilities, and has potentially conflicting resources when included with Splunk Enterprise on the same node.  Do not include splunk::forwarder on the same node as splunk::enterprise.  Configure Splunk Enterprise to meet your forwarding needs.'

--- a/manifests/enterprise.pp
+++ b/manifests/enterprise.pp
@@ -226,8 +226,8 @@ class splunk::enterprise (
   String[1] $seed_user                       = $splunk::params::seed_user,
   Stdlib::Absolutepath $secret_file          = $splunk::params::enterprise_secret_file,
   String[1] $secret                          = $splunk::params::secret,
-  String[1] $install_proxy                   = $splunk::params::install_proxy,
-  String[1] $install_proxy_type              = $splunk::params::install_proxy_type,
+  Optional[String[1]] $install_proxy         = $splunk::params::install_proxy,
+  Optional[String[1]] $install_proxy_type    = $splunk::params::install_proxy_type,
 ) inherits splunk {
   if (defined(Class['splunk::forwarder'])) {
     fail('Splunk Universal Forwarder provides a subset of Splunk Enterprise capabilities, and has potentially conflicting resources when included with Splunk Enterprise on the same node.  Do not include splunk::forwarder on the same node as splunk::enterprise.  Configure Splunk Enterprise to meet your forwarding needs.'

--- a/manifests/enterprise/install.pp
+++ b/manifests/enterprise/install.pp
@@ -19,9 +19,11 @@ class splunk::enterprise::install {
     $_staged_package       = join($_package_path_parts, $splunk::enterprise::path_delimiter)
 
     archive { $_staged_package:
-      source  => $_package_source,
-      extract => false,
-      before  => Package[$splunk::enterprise::package_name],
+      source       => $_package_source,
+      extract      => false,
+      before       => Package[$splunk::enterprise::package_name],
+      proxy_server => $splunk::enterprise::install_proxy,
+      proxy_type   => $splunk::enterprise::install_proxy_type,
     }
   } else {
     $_staged_package = undef

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -150,6 +150,12 @@
 # @param addons
 #   Manage a splunk addons, see `splunk::addons`.
 #
+# @param install_proxy
+#   Proxy used to install Splunk forwarder package.
+#
+# @param install_proxy_type
+#   Proxy type used to install Splunk forwarder package.
+#
 class splunk::forwarder (
   String[1] $server                          = $splunk::params::server,
   String[1] $version                         = $splunk::params::version,
@@ -191,6 +197,8 @@ class splunk::forwarder (
   Stdlib::Absolutepath $secret_file          = $splunk::params::forwarder_secret_file,
   String[1] $secret                          = $splunk::params::secret,
   Hash $addons                               = {},
+  String[1] $install_proxy                   = $splunk::params::install_proxy,
+  String[1] $install_proxy_type              = $splunk::params::install_proxy_type,
 ) inherits splunk {
   if (defined(Class['splunk::enterprise'])) {
     fail('Splunk Universal Forwarder provides a subset of Splunk Enterprise capabilities, and has potentially conflicting resources when included with Splunk Enterprise on the same node.  Do not include splunk::forwarder on the same node as splunk::enterprise.  Configure Splunk Enterprise to meet your forwarding needs.'

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -197,8 +197,8 @@ class splunk::forwarder (
   Stdlib::Absolutepath $secret_file          = $splunk::params::forwarder_secret_file,
   String[1] $secret                          = $splunk::params::secret,
   Hash $addons                               = {},
-  String[1] $install_proxy                   = $splunk::params::install_proxy,
-  String[1] $install_proxy_type              = $splunk::params::install_proxy_type,
+  Optional[String[1]] $install_proxy         = $splunk::params::install_proxy,
+  Optional[String[1]] $install_proxy_type    = $splunk::params::install_proxy_type,
 ) inherits splunk {
   if (defined(Class['splunk::enterprise'])) {
     fail('Splunk Universal Forwarder provides a subset of Splunk Enterprise capabilities, and has potentially conflicting resources when included with Splunk Enterprise on the same node.  Do not include splunk::forwarder on the same node as splunk::enterprise.  Configure Splunk Enterprise to meet your forwarding needs.'

--- a/manifests/forwarder/install.pp
+++ b/manifests/forwarder/install.pp
@@ -15,9 +15,12 @@ class splunk::forwarder::install {
     $_staged_package       = join($_package_path_parts, $splunk::forwarder::path_delimiter)
 
     archive { $_staged_package:
-      source  => $_package_source,
-      extract => false,
-      before  => Package[$splunk::forwarder::forwarder_package_name],
+      source       => $_package_source,
+      extract      => false,
+      before       => Package[$splunk::forwarder::forwarder_package_name],
+      proxy_server => $splunk::forwarder::install_proxy,
+      proxy_type   => $splunk::forwarder::install_proxy_type,
+
     }
   } else {
     $_staged_package = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,6 +89,12 @@
 # @param enterprise_installdir
 #   Optional directory in which to install and manage Splunk Enterprise
 #
+# @param install_proxy
+#   Optional proxy server URL for installing packages.
+#
+# @param install_proxy_type
+#   Optional proxy type (none|http|https|ftp).
+#
 # @param default_host
 #   The host property in inputs.conf. Defaults to the server's hostname.
 #
@@ -106,6 +112,8 @@ class splunk::params (
   String[1] $server                          = 'splunk',
   Optional[String[1]] $forwarder_installdir  = undef,
   Optional[String[1]] $enterprise_installdir = undef,
+  Optional[String[1]] $install_proxy         = undef,
+  Optional[String[1]] $install_proxy_type    = undef,
   Boolean $boot_start                        = true,
   String[1] $splunk_user                     = $facts['os']['family'] ? {
     'windows' => 'Administrator',


### PR DESCRIPTION

#### Pull Request (PR) description
This PR adds support to use a given proxy for install the forwarder and enterprise Splunk. It simply passes the options to puppet-archive.

#### This Pull Request (PR) fixes the following issues

