### PR TITLE
Solaris support

### DIFF
--- a/manifests/forwarder/install.pp
+++ b/manifests/forwarder/install.pp
@@ -61,7 +61,7 @@ class splunk::forwarder::install {
   }
 
   # Required for splunk 7.2.4.2
-  if $splunk::params::manage_net_tools and ($facts['kernel'] == 'Linux' or $facts['kernel'] == 'SunOS') and (versioncmp($splunk::forwarder::version, '7.2.4.2') >= 0) {
+  if $splunk::params::manage_net_tools and $facts['kernel'] == 'Linux' and (versioncmp($splunk::forwarder::version, '7.2.4.2') >= 0) {
     ensure_packages(['net-tools'], {
         'ensure' => 'present',
     })

--- a/manifests/forwarder/service/nix.pp
+++ b/manifests/forwarder/service/nix.pp
@@ -23,6 +23,13 @@ class splunk::forwarder::service::nix inherits splunk::forwarder::service {
     } else {
       $user_args = "-user ${splunk::forwarder::splunk_user}"
     }
+
+    if $facts['kernel'] == 'SunOS' {
+      Service[$splunk::forwarder::service_name] {
+        provider => 'init',
+      }
+    }
+
     # This will fail if the unit file already exists.  Splunk does not remove
     # unit files during uninstallation, so you may be required to manually
     # remove existing unit files before re-installing and enabling boot-start.

--- a/manifests/forwarder/service/nix.pp
+++ b/manifests/forwarder/service/nix.pp
@@ -18,9 +18,8 @@ class splunk::forwarder::service::nix inherits splunk::forwarder::service {
       timeout => 0,
       notify  => Exec['enable_splunkforwarder'],
     }
-    if $splunk::params::supports_systemd {
-      $user_args = "-user ${splunk::forwarder::splunk_user}"
-    }
+
+    $user_args = "-user ${splunk::forwarder::splunk_user}"
 
     if $facts['kernel'] == 'SunOS' {
       Service[$splunk::forwarder::service_name] {

--- a/manifests/forwarder/service/nix.pp
+++ b/manifests/forwarder/service/nix.pp
@@ -18,9 +18,7 @@ class splunk::forwarder::service::nix inherits splunk::forwarder::service {
       timeout => 0,
       notify  => Exec['enable_splunkforwarder'],
     }
-    if $splunk::params::supports_systemd and $splunk::forwarder::splunk_user == 'root' {
-      $user_args = ''
-    } else {
+    if $splunk::params::supports_systemd {
       $user_args = "-user ${splunk::forwarder::splunk_user}"
     }
 

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -112,7 +112,7 @@ describe 'splunk::forwarder' do
                 it { is_expected.to contain_class('splunk::forwarder::service::nix') }
                 it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'SplunkForwarder') }
                 it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop') }
-                it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start  -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunkforwarder') }
                 it { is_expected.not_to contain_exec('license_splunkforwarder') }
                 it { is_expected.to contain_service('SplunkForwarder').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes for permission startup when running as root user. 
Removal of net-tools due to this incorrectly being specified for SunOS.


#### This Pull Request (PR) fixes the following issues
Fixes #310 - it appears the default user for splunk has changed from root to splunk at some point. The default being root meant not explicitly specifying the user still worked. The resulted in the module config having root, file ownership having root, but the service starting as splunk due to it not being explicitly specified.

Partially fixes #272 - Net-tools removed. On the other issue reported, using the .pkg file, it appears Splunk no longer ship a .pkg format installer. Only .p5p and .Z. I had issues getting .p5p support working because I'm using Solaris zones, and this is incompatible with the way the installer works (Solaris zones need a pkg provider defined in the global zone, and cant install .p5p files without this).

My workaround for the missing .pkg download was to build a .pkg file myself using pkgbuild. Due to licensing I dont think I'm able to distribute the build package but I've put pkgbuild spec file and some instructions in this git repo:
https://github.com/davemcdonnell/splunk-solarispkg

With all of the above I've got splunk forwarder running on Solaris 11.4.45 with splunkforwarder 9.0.0.

