### PR TITLE
Explicitly set user on call to 'splunk enable boot-start'

### DIFF
--- a/manifests/forwarder/service/nix.pp
+++ b/manifests/forwarder/service/nix.pp
@@ -18,11 +18,9 @@ class splunk::forwarder::service::nix inherits splunk::forwarder::service {
       timeout => 0,
       notify  => Exec['enable_splunkforwarder'],
     }
-    if $splunk::params::supports_systemd and $splunk::forwarder::splunk_user == 'root' {
-      $user_args = ''
-    } else {
-      $user_args = "-user ${splunk::forwarder::splunk_user}"
-    }
+
+    $user_args = "-user ${splunk::forwarder::splunk_user}"
+
     # This will fail if the unit file already exists.  Splunk does not remove
     # unit files during uninstallation, so you may be required to manually
     # remove existing unit files before re-installing and enabling boot-start.

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -112,7 +112,7 @@ describe 'splunk::forwarder' do
                 it { is_expected.to contain_class('splunk::forwarder::service::nix') }
                 it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'SplunkForwarder') }
                 it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop') }
-                it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start  -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
+                it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
                 it { is_expected.not_to contain_exec('disable_splunkforwarder') }
                 it { is_expected.not_to contain_exec('license_splunkforwarder') }
                 it { is_expected.to contain_service('SplunkForwarder').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }


### PR DESCRIPTION
Fixes #310

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Fixes for permission startup when running as root user.

#### This Pull Request (PR) fixes the following issues
Fixes #310 - it appears the default user for splunk has changed from root to splunk at some point. The default being root meant not explicitly specifying the user still worked until the default changed to splunk. The resulted in the module config having root, file ownership having root, but the service starting as splunk due to it not being explicitly specified.