### PR TITLE
Use init provider on solaris when managing service

### DIFF
--- a/manifests/forwarder/service/nix.pp
+++ b/manifests/forwarder/service/nix.pp
@@ -21,6 +21,12 @@ class splunk::forwarder::service::nix inherits splunk::forwarder::service {
 
     $user_args = "-user ${splunk::forwarder::splunk_user}"
 
+    if $facts['kernel'] == 'SunOS' {
+      Service[$splunk::forwarder::service_name] {
+        provider => 'init',
+      }
+    }
+
     # This will fail if the unit file already exists.  Splunk does not remove
     # unit files during uninstallation, so you may be required to manually
     # remove existing unit files before re-installing and enabling boot-start.


### PR DESCRIPTION


#### Pull Request (PR) description
Puppet on Solaris defaults to the SMF provider for services. Splunk is still using init scripts (as of latest version 9.0.0).

Puppet attempts to enable the service, which causes a catalog failure:
Error: Could not start Service[splunk]: Execution of '/usr/sbin/svcadm enable -rs splunk' returned 1: svcadm: Pattern 'splunk' doesn't match any instances
Error: /Stage[main]/Splunk::Forwarder::Service/Service[splunk]/ensure: change from 'stopped' to 'running' failed: Could not start Service[splunk]: Execution of '/usr/sbin/svcadm enable -rs splunk' returned 1: svcadm: Pattern 'splunk' doesn't match any instances


#### This Pull Request (PR) fixes the following issues
No bug logged for this
