### PR TITLE
Safer Splunk Enterprise version check

### DIFF
--- a/lib/facter/splunk_version.rb
+++ b/lib/facter/splunk_version.rb
@@ -4,7 +4,7 @@ Facter.add(:splunk_version) do
     cmd = if File.exist?('C:/Program Files/Splunk/bin/splunk.exe')
             '"C:/Program Files/Splunk/bin/splunk.exe" --version'
           elsif File.exist?('/opt/splunk/bin/splunk')
-            '/opt/splunk/bin/splunk --version'
+            '/opt/splunk/bin/splunk --version --accept-license --answer-yes --no-prompt'
           end
     if cmd
       output = Facter::Util::Resolution.exec(cmd)

--- a/spec/unit/facter/splunk_version_spec.rb
+++ b/spec/unit/facter/splunk_version_spec.rb
@@ -14,7 +14,7 @@ describe 'splunk_version Fact' do
   it 'returns version for Linux' do
     allow(File).to receive(:exist?).with('C:/Program Files/Splunk/bin/splunk.exe').and_return(false)
     allow(File).to receive(:exist?).with('/opt/splunk/bin/splunk').and_return(true)
-    allow(Facter::Util::Resolution).to receive(:exec).with('/opt/splunk/bin/splunk --version').and_return('Splunk 6.6.8 (build 6c27a8439c1e)')
+    allow(Facter::Util::Resolution).to receive(:exec).with('/opt/splunk/bin/splunk --version --accept-license --answer-yes --no-prompt').and_return('Splunk 6.6.8 (build 6c27a8439c1e)')
     expect(Facter.fact(:splunk_version).value).to eq('6.6.8')
   end
 


### PR DESCRIPTION
#### Pull Request (PR) description
Interactive Puppet runs can hang on a facter Splunk version check immediately following a Splunk Enterprise package upgrade. This change makes the version check arguments in splunk_version.rb match those added to the version check in splunkforwarder_version.rb in commit 5778673ee.

#### This Pull Request (PR) fixes the following issues
n/a
