### PR TITLE
enable the puppet-archive `allow_insecure` parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -888,6 +888,7 @@ The following parameters are available in the `splunk::forwarder` class:
 * [`secret_file`](#-splunk--forwarder--secret_file)
 * [`secret`](#-splunk--forwarder--secret)
 * [`addons`](#-splunk--forwarder--addons)
+* [`allow_insecure`](#-splunk--forwarder--allow_insecure)
 * [`purge_deploymentclient`](#-splunk--forwarder--purge_deploymentclient)
 
 ##### <a name="-splunk--forwarder--server"></a>`server`
@@ -1221,6 +1222,14 @@ Manage a splunk addons, see `splunk::addons`.
 
 Default value: `{}`
 
+##### <a name="-splunk--forwarder--allow_insecure"></a>`allow_insecure`
+
+Data type: `Boolean`
+
+Disable certificate verification when connecting to SSL hosts to download packages.
+
+Default value: `$splunk::params::allow_insecure`
+
 ##### <a name="-splunk--forwarder--purge_deploymentclient"></a>`purge_deploymentclient`
 
 Data type: `Boolean`
@@ -1477,6 +1486,7 @@ The following parameters are available in the `splunk::params` class:
 * [`enterprise_installdir`](#-splunk--params--enterprise_installdir)
 * [`default_host`](#-splunk--params--default_host)
 * [`manage_net_tools`](#-splunk--params--manage_net_tools)
+* [`allow_insecure`](#-splunk--params--allow_insecure)
 
 ##### <a name="-splunk--params--version"></a>`version`
 
@@ -1635,6 +1645,14 @@ By default this module manages the resource Package[net-tools], if this resource
 already declared on your code base, you can disable this flag.
 
 Default value: `true`
+
+##### <a name="-splunk--params--allow_insecure"></a>`allow_insecure`
+
+Data type: `Boolean`
+
+Disable certificate verification when connecting to SSL hosts to download packages.
+
+Default value: `false`
 
 ## Defined types
 

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -150,6 +150,9 @@
 # @param addons
 #   Manage a splunk addons, see `splunk::addons`.
 #
+# @param allow_insecure
+#   Disable certificate verification when connecting to SSL hosts to download packages.
+#
 class splunk::forwarder (
   String[1] $server                          = $splunk::params::server,
   String[1] $version                         = $splunk::params::version,
@@ -191,6 +194,7 @@ class splunk::forwarder (
   Stdlib::Absolutepath $secret_file          = $splunk::params::forwarder_secret_file,
   String[1] $secret                          = $splunk::params::secret,
   Hash $addons                               = {},
+  Boolean $allow_insecure                    = $splunk::params::allow_insecure,
 ) inherits splunk {
   if (defined(Class['splunk::enterprise'])) {
     fail('Splunk Universal Forwarder provides a subset of Splunk Enterprise capabilities, and has potentially conflicting resources when included with Splunk Enterprise on the same node.  Do not include splunk::forwarder on the same node as splunk::enterprise.  Configure Splunk Enterprise to meet your forwarding needs.'

--- a/manifests/forwarder/install.pp
+++ b/manifests/forwarder/install.pp
@@ -15,9 +15,10 @@ class splunk::forwarder::install {
     $_staged_package       = join($_package_path_parts, $splunk::forwarder::path_delimiter)
 
     archive { $_staged_package:
-      source  => $_package_source,
-      extract => false,
-      before  => Package[$splunk::forwarder::forwarder_package_name],
+      source         => $_package_source,
+      extract        => false,
+      allow_insecure => $splunk::forwarder::allow_insecure,
+      before         => Package[$splunk::forwarder::forwarder_package_name],
     }
   } else {
     $_staged_package = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -97,6 +97,9 @@
 #   By default this module manages the resource Package[net-tools], if this resource is
 #   already declared on your code base, you can disable this flag.
 #
+# @param allow_insecure
+#   Disable certificate verification when connecting to SSL hosts to download packages.
+#
 class splunk::params (
   String[1] $version                         = '7.2.4.2',
   String[1] $build                           = 'fb30470262e3',
@@ -113,6 +116,7 @@ class splunk::params (
   },
   String[1] $default_host                    = $facts['clientcert'],
   Boolean $manage_net_tools                  = true,
+  Boolean $allow_insecure                    = false,
 ) {
   # Based on the small number of inputs above, we can construct sane defaults
   # for pretty much everything else.


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Enable the 'allow_insecure' parameter, which is provided by puppet-archive. Otherwise, self-signed certificates on a hosted artifact repository will throw an SSL error.
-->

#### This Pull Request (PR) fixes the following issues
<!--
N/A
-->
