### PR TITLE
Increase dependency range for puppetlabs-sourced dependencies.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -78,15 +78,15 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.25.0 < 9.0.0"
+      "version_requirement": ">= 4.25.0 < 10.0.0"
     },
     {
       "name": "puppetlabs-inifile",
-      "version_requirement": ">= 1.4.1 < 6.0.0"
+      "version_requirement": ">= 1.4.1 < 7.0.0"
     },
     {
       "name": "puppetlabs-concat",
-      "version_requirement": ">= 4.2.1 < 8.0.0"
+      "version_requirement": ">= 4.2.1 < 9.0.0"
     },
     {
       "name": "puppet-archive",


### PR DESCRIPTION
#### Pull Request (PR) description
stdlib, inifile, concat all had major revisions for dropping puppet6, which this module already did.

#### This Pull Request (PR) fixes the following issues