### PR TITLE
Allow the user to set encrypted values directly

### DIFF
--- a/lib/puppet_x/puppetlabs/splunk/type.rb
+++ b/lib/puppet_x/puppetlabs/splunk/type.rb
@@ -32,10 +32,11 @@ module PuppetX
             end
             def insync?(is) # rubocop:disable Lint/NestedMethodDefinition
               secrets_file_path = File.join(provider.class.file_path, 'auth/splunk.secret')
-              if File.file?(secrets_file_path)
+              secrets_file_exist = File.file?(secrets_file_path)
+              if !should.start_with?('$7$') && secrets_file_exist
                 PuppetX::Voxpupuli::Splunk::Util.decrypt(secrets_file_path, is) == should
               else
-                Puppet.warning('Secrets file NOT found')
+                Puppet.warning("Secrets file NOT found in #{secrets_file_path}") unless secrets_file_exist
                 is == should
               end
             end

--- a/spec/unit/puppet/type/splunk_types_spec.rb
+++ b/spec/unit/puppet/type/splunk_types_spec.rb
@@ -103,6 +103,13 @@ SPLUNK_TYPES.each do |type, file_name|
           allow(IO).to receive(:binread).with(%r{/opt/splunk(forwarder)?/etc/auth/splunk\.secret$}).and_return('JX7cQAnH6Nznmild8MvfN8/BLQnGr8C3UYg3mqvc3ArFkaxj4gUt1RUCaRBD/r0CNn8xOA2oKX8/0uyyChyGRiFKhp6h2FA+ydNIRnN46N8rZov8QGkchmebZa5GAM5U50GbCCgzJFObPyWi5yT8CrSCYmv9cpRtpKyiX+wkhJwltoJzAxWbBERiLp+oXZnN3lsRn6YkljmYBqN9tZLTVVpsLvqvkezPgpv727Fd//5dRoWsWBv2zRp0mwDv3tj')
           expect(property).to be_safe_insync('$7$aTVkS01HYVNJUk5wSnR5NIu4GXLhj2Qd49n2B6Y8qmA/u1CdL9JYxQ==')
         end
+
+        it 'is insync if `should` is encrypted' do
+          property.should = '$7$aTVkS01HYVNJUk5wSnR5NIu4GXLhj2Qd49n2B6Y8qmA/u1CdL9JYxQ=='
+          allow(File).to receive(:file?).with(%r{/opt/splunk(forwarder)?/etc/auth/splunk\.secret$}).and_return(true)
+          allow(IO).to receive(:binread).with(%r{/opt/splunk(forwarder)?/etc/auth/splunk\.secret$}).and_return('JX7cQAnH6Nznmild8MvfN8/BLQnGr8C3UYg3mqvc3ArFkaxj4gUt1RUCaRBD/r0CNn8xOA2oKX8/0uyyChyGRiFKhp6h2FA+ydNIRnN46N8rZov8QGkchmebZa5GAM5U50GbCCgzJFObPyWi5yT8CrSCYmv9cpRtpKyiX+wkhJwltoJzAxWbBERiLp+oXZnN3lsRn6YkljmYBqN9tZLTVVpsLvqvkezPgpv727Fd//5dRoWsWBv2zRp0mwDv3tj')
+          expect(property).to be_safe_insync('$7$aTVkS01HYVNJUk5wSnR5NIu4GXLhj2Qd49n2B6Y8qmA/u1CdL9JYxQ==')
+        end
       end
     end
   end


### PR DESCRIPTION
Before it was only possible to set an encrypted value by setting it in plain text. If the encrypted value was given, there was and endless re-apply happening because Splunk encrypts the values during boot time thus changing the value.

Now it's also possible to set the values by providing the encrypted value directly.

#### This Pull Request (PR) fixes the following issues
Fixes #284 (Maybe #197 ?) 