### PR TITLE
Enable unit tests for Windows

### DIFF
--- a/manifests/forwarder/config.pp
+++ b/manifests/forwarder/config.pp
@@ -31,9 +31,11 @@ class splunk::forwarder::config {
   }
 
   # Remove init.d file if the service provider is systemd
-  if $facts['service_provider'] == 'systemd' and versioncmp($splunk::forwarder::version, '7.2.2') >= 0 {
-    file { '/etc/init.d/splunk':
-      ensure => 'absent',
+  if $facts['os']['name'] != 'windows' {
+    if $facts['service_provider'] == 'systemd' and versioncmp($splunk::forwarder::version, '7.2.2') >= 0 {
+      file { '/etc/init.d/splunk':
+        ensure => 'absent',
+      }
     }
   }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Windows was not being tested at all with the `splunk::forwarder` class even though it is supported.

#### This Pull Request (PR) fixes the following issues
Windows is now tested. Made sure existing tests for other OSes continued to work.
