### PR TITLE
Treat the forwarder user as a separate parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -994,13 +994,7 @@ Data type: `String[1]`
 
 The user to run Splunk as.
 
-Default value:
-
-```puppet
-versioncmp($version, '9.1.0') ? {
-    -1 => $splunk::params::splunk_user,
-    default => 'splunkfwd'
-```
+Default value: `$splunk::params::splunk_forwarder_user`
 
 ##### <a name="-splunk--forwarder--forwarder_homedir"></a>`forwarder_homedir`
 
@@ -1486,6 +1480,7 @@ The following parameters are available in the `splunk::params` class:
 * [`logging_port`](#-splunk--params--logging_port)
 * [`server`](#-splunk--params--server)
 * [`splunk_user`](#-splunk--params--splunk_user)
+* [`splunk_forwarder_user`](#-splunk--params--splunk_forwarder_user)
 * [`src_root`](#-splunk--params--src_root)
 * [`boot_start`](#-splunk--params--boot_start)
 * [`forwarder_installdir`](#-splunk--params--forwarder_installdir)
@@ -1552,6 +1547,20 @@ Default value:
 $facts['os']['family'] ? {
     'windows' => 'Administrator',
     default => versioncmp($version, '8.0.0') ? { -1 => 'root', default => 'splunk'
+```
+
+##### <a name="-splunk--params--splunk_forwarder_user"></a>`splunk_forwarder_user`
+
+Data type: `String[1]`
+
+The user that splunk forwarder runs as.
+
+Default value:
+
+```puppet
+$facts['os']['family'] ? {
+    'windows' => versioncmp($version, '9.1.0') ? { -1 => 'Administrator', default => 'NT SERVICE\\SplunkForwarder' },
+    default => versioncmp($version, '9.1.0') ? { -1 => 'root', default => 'splunkfwd'
 ```
 
 ##### <a name="-splunk--params--src_root"></a>`src_root`

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -165,10 +165,7 @@ class splunk::forwarder (
   Boolean $manage_package_source             = true,
   Optional[String[1]] $package_source        = undef,
   Splunk::Fwdinstalloptions $install_options = $splunk::params::forwarder_install_options,
-  String[1] $splunk_user                     = versioncmp($version, '9.1.0') ? {
-    -1 => $splunk::params::splunk_user,
-    default => 'splunkfwd',
-  },
+  String[1] $splunk_user                     = $splunk::params::splunk_forwarder_user,
   Stdlib::Absolutepath $forwarder_homedir    = $splunk::params::forwarder_homedir,
   Stdlib::Absolutepath $forwarder_confdir    = $splunk::params::forwarder_confdir,
   String[1] $service_name                    = $splunk::params::forwarder_service,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -118,7 +118,7 @@ class splunk::params (
     default => versioncmp($version, '8.0.0') ? { -1 => 'root', default => 'splunk' },
   },
   String[1] $splunk_forwarder_user           = $facts['os']['family'] ? {
-    'windows' => versioncmp($version, '9.1.0') ? { -1 => 'Administrator', default => 'splunkfwd' },
+    'windows' => versioncmp($version, '9.1.0') ? { -1 => 'Administrator', default => 'NT SERVICE\\SplunkForwarder' },
     default => versioncmp($version, '9.1.0') ? { -1 => 'root', default => 'splunkfwd' },
   },
   String[1] $default_host                    = $facts['clientcert'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,9 @@
 # @param splunk_user
 #   The user that splunk runs as.
 #
+# @param splunk_forwarder_user
+#   The user that splunk forwarder runs as.
+#
 # @param src_root
 #   The root URL at which to find the splunk packages. The sane-default logic
 #   assumes that the packages are located under this URL in the same way that
@@ -113,6 +116,10 @@ class splunk::params (
   String[1] $splunk_user                     = $facts['os']['family'] ? {
     'windows' => 'Administrator',
     default => versioncmp($version, '8.0.0') ? { -1 => 'root', default => 'splunk' },
+  },
+  String[1] $splunk_forwarder_user           = $facts['os']['family'] ? {
+    'windows' => versioncmp($version, '9.1.0') ? { -1 => 'Administrator', default => 'splunkfwd' },
+    default => versioncmp($version, '9.1.0') ? { -1 => 'root', default => 'splunkfwd' },
   },
   String[1] $default_host                    = $facts['clientcert'],
   Boolean $manage_net_tools                  = true,

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -245,6 +245,31 @@ describe 'splunk::forwarder' do
           end
         end
 
+        context 'when forwarder version is less than 9.1.0' do
+          let(:pre_condition) do
+            "class { 'splunk::params': version => '9.0.0' }"
+          end
+
+          if facts[:os]['name'] == 'windows'
+            it { is_expected.to contain_file('C:\\Program Files\\SplunkUniversalForwarder/etc/system/local/inputs.conf').with('owner' => 'Administrator') }
+          else
+            it { is_expected.to contain_file('/opt/splunkforwarder/etc/system/local/inputs.conf').with('owner' => 'root') }
+          end
+        end
+
+        # The default user that the forwarder uses was changed in verison 9.1.0
+        context 'when forwarder version is greater or equal to 9.1.0' do
+          let(:pre_condition) do
+            "class { 'splunk::params': version => '9.1.0' }"
+          end
+
+          if facts[:os]['name'] == 'windows'
+            it { is_expected.to contain_file('C:\\Program Files\\SplunkUniversalForwarder/etc/system/local/inputs.conf').with('owner' => 'NT SERVICE\\SplunkForwarder') }
+          else
+            it { is_expected.to contain_file('/opt/splunkforwarder/etc/system/local/inputs.conf').with('owner' => 'splunkfwd') }
+          end
+        end
+
         context 'when forwarder not already installed' do
           let(:facts) do
             facts.merge(splunkforwarder_version: nil, service_provider: facts[:kernel] == 'FreeBSD' ? 'freebsd' : 'systemd')


### PR DESCRIPTION
#### Pull Request (PR) description
Now the forwarder uses a completely different user name. I thought using a new `splunk::params::splunk_forwarder_user` would make things cleaner.

It also sets the forwarder user to the correct default user for Windows.

#### This Pull Request (PR) fixes the following issues
Fixes #369 
