### PR TITLE
Correct `splunk.secret` path

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -159,8 +159,8 @@ class splunk::params (
       $enterprise_seed_config_file     = "${enterprise_homedir}/etc/system/local/user-seed.conf"
       $forwarder_password_config_file  = "${forwarder_homedir}/etc/passwd"
       $enterprise_password_config_file = "${enterprise_homedir}/etc/passwd"
-      $forwarder_secret_file           = "${forwarder_homedir}/etc/splunk.secret"
-      $enterprise_secret_file          = "${enterprise_homedir}/etc/splunk.secret"
+      $forwarder_secret_file           = "${forwarder_homedir}/etc/auth/splunk.secret"
+      $enterprise_secret_file          = "${enterprise_homedir}/etc/auth/splunk.secret"
       $forwarder_confdir               = "${forwarder_homedir}/etc"
       $enterprise_src_subdir           = 'linux'
       $enterprise_confdir              = "${enterprise_homedir}/etc"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -191,8 +191,8 @@ class splunk::params (
       $enterprise_seed_config_file     = "${enterprise_homedir}/etc/system/local/user-seed.conf"
       $forwarder_password_config_file  = "${forwarder_homedir}/etc/passwd"
       $enterprise_password_config_file = "${enterprise_homedir}/etc/passwd"
-      $forwarder_secret_file           = "${forwarder_homedir}/etc/splunk.secret"
-      $enterprise_secret_file          = "${enterprise_homedir}/etc/splunk.secret"
+      $forwarder_secret_file           = "${forwarder_homedir}/etc/auth/splunk.secret"
+      $enterprise_secret_file          = "${enterprise_homedir}/etc/auth/splunk.secret"
       $forwarder_confdir               = "${forwarder_homedir}/etc"
       $enterprise_src_subdir           = 'solaris'
       $enterprise_confdir              = "${enterprise_homedir}/etc"
@@ -223,8 +223,8 @@ class splunk::params (
       $enterprise_seed_config_file     = "${enterprise_homedir}/etc/system/local/user-seed.conf"
       $forwarder_password_config_file  = "${forwarder_homedir}/etc/passwd"
       $enterprise_password_config_file = "${enterprise_homedir}/etc/passwd"
-      $forwarder_secret_file           = "${forwarder_homedir}/etc/splunk.secret"
-      $enterprise_secret_file          = "${enterprise_homedir}/etc/splunk.secret"
+      $forwarder_secret_file           = "${forwarder_homedir}/etc/auth/splunk.secret"
+      $enterprise_secret_file          = "${enterprise_homedir}/etc/auth/splunk.secret"
       $forwarder_confdir               = "${forwarder_homedir}/etc"
       $enterprise_src_subdir           = 'freebsd'
       $enterprise_confdir              = "${enterprise_homedir}/etc"
@@ -244,8 +244,8 @@ class splunk::params (
       $enterprise_seed_config_file     = "${enterprise_homedir}\\etc\\system\\local\\user-seed.conf"
       $forwarder_password_config_file  = "${forwarder_homedir}\\etc\\passwd"
       $enterprise_password_config_file = "${enterprise_homedir}\\etc\\passwd"
-      $forwarder_secret_file           = "${forwarder_homedir}\\etc\\splunk.secret"
-      $enterprise_secret_file          = "${enterprise_homedir}\\etc\\splunk.secret"
+      $forwarder_secret_file           = "${forwarder_homedir}\\etc\\auth\\splunk.secret"
+      $enterprise_secret_file          = "${enterprise_homedir}\\etc\\auth\\splunk.secret"
       $forwarder_service               = 'SplunkForwarder'
       $forwarder_service_file          = "${forwarder_homedir}\\dummy" # Not used in Windows, but attribute must be defined with a valid path
       $forwarder_confdir               = "${forwarder_homedir}\\etc"

--- a/spec/classes/enterprise_spec.rb
+++ b/spec/classes/enterprise_spec.rb
@@ -121,7 +121,7 @@ describe 'splunk::enterprise' do
           let(:params) { { 'manage_password' => true } }
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_file('/opt/splunk/etc/splunk.secret') }
+          it { is_expected.to contain_file('/opt/splunk/etc/auth/splunk.secret') }
           it { is_expected.to contain_file('/opt/splunk/etc/passwd') }
         end
       end

--- a/spec/classes/enterprise_spec.rb
+++ b/spec/classes/enterprise_spec.rb
@@ -34,7 +34,7 @@ shared_examples_for 'splunk enterprise nix defaults' do
   it { is_expected.to contain_splunk_input('default_splunktcp').with(section: 'splunktcp://:9997', value: 'dns') }
   it { is_expected.to contain_splunk_web('splunk_server_splunkd_port').with(value: '127.0.0.1:8089') }
   it { is_expected.to contain_splunk_web('splunk_server_web_port').with(value: '8000') }
-  it { is_expected.not_to contain_file('/opt/splunk/etc/splunk.secret') }
+  it { is_expected.not_to contain_file('/opt/splunk/etc/auth/splunk.secret') }
   it { is_expected.not_to contain_file('/opt/splunk/etc/passwd') }
 end
 

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -34,7 +34,7 @@ describe 'splunk::forwarder' do
           it { is_expected.to contain_file('C:\\Program Files\\SplunkUniversalForwarder/etc/system/local/transforms.conf') }
           it { is_expected.to contain_file('C:\\Program Files\\SplunkUniversalForwarder/etc/system/local/web.conf') }
           it { is_expected.to contain_file('C:\\Program Files\\SplunkUniversalForwarder/etc/system/local/server.conf') }
-          it { is_expected.not_to contain_file('C:\\Program Files\\SplunkUniversalForwarder/etc/splunk.secret') }
+          it { is_expected.not_to contain_file('C:\\Program Files\\SplunkUniversalForwarder/etc/auth/splunk.secret') }
           it { is_expected.not_to contain_file('C:\\Program Files\\SplunkUniversalForwarder/etc/passwd') }
         else
           it { is_expected.to contain_package('splunkforwarder').with(ensure: 'installed') }
@@ -46,7 +46,7 @@ describe 'splunk::forwarder' do
           it { is_expected.to contain_file('/opt/splunkforwarder/etc/system/local/transforms.conf') }
           it { is_expected.to contain_file('/opt/splunkforwarder/etc/system/local/web.conf') }
           it { is_expected.to contain_file('/opt/splunkforwarder/etc/system/local/server.conf') }
-          it { is_expected.not_to contain_file('/opt/splunkforwarder/etc/splunk.secret') }
+          it { is_expected.not_to contain_file('/opt/splunkforwarder/etc/auth/splunk.secret') }
           it { is_expected.not_to contain_file('/opt/splunkforwarder/etc/passwd') }
         end
         it { is_expected.to compile.with_all_deps }
@@ -64,7 +64,7 @@ describe 'splunk::forwarder' do
             let(:params) { { 'manage_password' => true } }
 
             it { is_expected.to compile.with_all_deps }
-            it { is_expected.to contain_file('/opt/splunkforwarder/etc/splunk.secret') }
+            it { is_expected.to contain_file('/opt/splunkforwarder/etc/auth/splunk.secret') }
             it { is_expected.to contain_file('/opt/splunkforwarder/etc/passwd') }
           end
         end


### PR DESCRIPTION
#### Pull Request (PR) description

The `splunk.secret` file on Linux is located at `$SPLUNK_HOME/etc/auth` instead of `$SPLUNK_HOME/etc/` as per [Splunk documentation](https://docs.splunk.com/Documentation/Splunk/9.3.0/Security/Deploysecurepasswordsacrossmultipleservers) since at least v7.0.0 through v9.3.0

#### This Pull Request (PR) fixes the following issues
Fixes #324 

