### PR TITLE
Adding deploymentclient.conf management

### DIFF
--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -114,6 +114,9 @@
 #   *Optional* If set to true, web.conf will be purged of configuration that is
 #   no longer managed by the `splunk_web` type.
 #
+# @param forwarder_deploymentclient
+#   Used to override the default `forwarder_deploymentclient` type defined in splunk::params.
+#
 # @param forwarder_input
 #   Used to override the default `forwarder_input` type defined in splunk::params.
 #
@@ -192,6 +195,7 @@ class splunk::forwarder (
   Boolean $purge_props                       = false,
   Boolean $purge_transforms                  = false,
   Boolean $purge_web                         = false,
+  Hash $forwarder_deploymentclient           = $splunk::params::forwarder_deploymentclient,
   Hash $forwarder_output                     = $splunk::params::forwarder_output,
   Hash $forwarder_input                      = $splunk::params::forwarder_input,
   Boolean $manage_password                   = $splunk::params::manage_password,

--- a/manifests/forwarder/config.pp
+++ b/manifests/forwarder/config.pp
@@ -67,6 +67,14 @@ class splunk::forwarder::config {
       tag     => 'splunk_forwarder',
     }
 
+    $splunk::forwarder::forwarder_deploymentclient.each | String $name, Hash $options| {
+      splunkforwarder_deploymentclient { $name:
+        section => $options['section'],
+        setting => $options['setting'],
+        value   => $options['value'],
+        tag     => 'splunk_forwarder',
+      }
+    }
     $splunk::forwarder::forwarder_input.each | String $name, Hash $options| {
       splunkforwarder_input { $name:
         section => $options['section'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -280,6 +280,14 @@ class splunk::params (
   }
   # default splunk agent settings in a hash so that the cya be easily parsed to other classes
 
+  $forwarder_deploymentclient = {
+    'target-broker_targetUri' => {
+      section             => 'target-broker:deploymentServer',
+      setting             => 'targetUri',
+      value               => "${server}:${logging_port}",
+      tag                 => 'splunk_forwarder',
+    },
+  }
   $forwarder_output = {
     'tcpout_defaultgroup' => {
       section             => 'default',


### PR DESCRIPTION
When installing splunkforwarder with the agent, `deploymentclient.conf` is part of the files that are being configured.

Puppet should manage `deploymentclient.conf` and it should be written with the following:

```
[target-broker:deploymentServer]
targetUri = <host>:<port>
```

With this commit, `deploymentclient.conf` will be configurable with something like this:

```
splunk::params::logging_port: 8089
splunk::params::server: 'scplunk01v.pwedc.local'
```