### PR TITLE
Patch 1

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -357,7 +357,10 @@ class splunk::params (
       $enterprise_package_name = 'splunk'
     }
     'Debian aarch64': {
-      $package_suffix          = "${version}-${build}-${deb_prefix}-arm64.deb"
+      $package_suffix = versioncmp($version, '9.4.0') >= 0 ? {
+        true  => "${version}-${build}-linux-arm64.deb",
+        false => "${version}-${build}-Linux-armv8.deb"
+      }
       $forwarder_package_name  = 'splunkforwarder'
       $enterprise_package_name = 'splunk'
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -356,6 +356,11 @@ class splunk::params (
       $forwarder_package_name  = 'splunkforwarder'
       $enterprise_package_name = 'splunk'
     }
+    'Debian aarch64': {
+      $package_suffix          = "${version}-${build}-${deb_prefix}-arm64.deb"
+      $forwarder_package_name  = 'splunkforwarder'
+      $enterprise_package_name = 'splunk'
+    }
     /^(W|w)indows (x86|i386)$/: {
       $package_suffix          = "${version}-${build}-x86-release.msi"
       $forwarder_package_name  = 'UniversalForwarder'


### PR DESCRIPTION
#### Pull Request (PR) description

Add support for downloading aarch64 Splunk forwarder packages for Debian; I can't find aarch64 packages for Splunk enterprise, so I assume those have not yet been released.

I only needed the last version of the Splunk forwarder package (9.4.0), but I accidentally discovered that the naming convention of the packages has been changed with version 9.4.0. The 9.4.0 package name ends with '-linux-arm64.deb', while earlier versions end with '-Linux-armv8.deb'. I've accounted for this in the PR, but I've not tested it (I've only downloaded and installed 9.4.0). Also aarch64 package versions before version 9.0.1 don't seem to exist.

#### This Pull Request (PR) fixes the following issues

n/a
