### PR TITLE
Fix ownership and upgrade handling for Splunk Forwarder

### DIFF
--- a/manifests/addon.pp
+++ b/manifests/addon.pp
@@ -83,7 +83,12 @@ define splunk::addon (
         extract_command => $extract_command,
         creates         => "${_splunk_home}/etc/apps/${name}",
         cleanup         => true,
-        before          => File["${_splunk_home}/etc/apps/${name}/local"],
+      }
+
+      exec { "splunkaddon-fix-ownership-${name}":
+        command => "/bin/chown -R ${owner}:${owner} ${_splunk_home}/etc/apps/${name}",
+        onlyif  => "/usr/bin/test -d ${_splunk_home}/etc/apps/${name}",
+        before  => File["${_splunk_home}/etc/apps/${name}/local"],
       }
     } else {
       package { $package_name:

--- a/manifests/forwarder/install.pp
+++ b/manifests/forwarder/install.pp
@@ -80,4 +80,72 @@ class splunk::forwarder::install {
     provider        => $splunk::forwarder::package_provider,
     install_options => $splunk::forwarder::install_options,
   }
+
+  if $facts['kernel'] == 'Linux' and $facts['service_provider'] == 'systemd' and $splunk::forwarder::boot_start {
+    if $facts['splunkforwarder_version'] and versioncmp($facts['splunkforwarder_version'], $splunk::forwarder::version) != 0 {
+      $_splunk_home = $splunk::forwarder::forwarder_homedir
+      $_splunk_user = $splunk::forwarder::splunk_user
+
+      case $facts['os']['family'] {
+        'RedHat', 'Suse': {
+          $_staged_file = "${splunk::forwarder::staging_dir}/splunkforwarder-${splunk::forwarder::version}-*.x86_64.rpm"
+          $_install_cmd = "/bin/rpm -U --force ${_staged_file}"
+        }
+        'Debian': {
+          $_staged_file = "${splunk::forwarder::staging_dir}/splunkforwarder-${splunk::forwarder::version}-*-amd64.deb"
+          $_install_cmd = "/usr/bin/dpkg -i ${_staged_file}"
+        }
+        default: {
+          $_staged_file = undef
+          $_install_cmd = undef
+        }
+      }
+
+      exec { 'splunkforwarder-disable-boot-start':
+        command => "${_splunk_home}/bin/splunk disable boot-start -user ${_splunk_user} --accept-license --answer-yes --no-prompt || true",
+        onlyif  => "/usr/bin/test -f ${_splunk_home}/bin/splunk",
+        timeout => 120,
+      }
+
+      exec { 'splunkforwarder-stop-for-upgrade':
+        command => "${_splunk_home}/bin/splunk stop",
+        onlyif  => "/usr/bin/test -f ${_splunk_home}/bin/splunk",
+        timeout => 120,
+      }
+
+      if $_staged_file and $_install_cmd {
+        exec { 'splunkforwarder-install-package':
+          command => $_install_cmd,
+          onlyif  => "ls ${_staged_file}",
+          timeout => 300,
+        }
+
+        exec { 'splunkforwarder-enable-boot-start-after-upgrade':
+          command => "${_splunk_home}/bin/splunk enable boot-start -user ${_splunk_user} -group ${_splunk_user} --accept-license --answer-yes --no-prompt",
+          onlyif  => "/usr/bin/test -f ${_splunk_home}/bin/splunk",
+          returns => [0, 4],
+          timeout => 120,
+        }
+
+        exec { 'splunkforwarder-fix-ownership':
+          command => "/bin/chown -R ${_splunk_user}:${_splunk_user} ${_splunk_home}",
+          onlyif  => "/usr/bin/test -d ${_splunk_home}",
+          timeout => 120,
+        }
+
+        Exec['splunkforwarder-enable-boot-start-after-upgrade'] -> Exec['splunkforwarder-fix-ownership']
+
+        Exec['splunkforwarder-disable-boot-start'] -> Exec['splunkforwarder-stop-for-upgrade'] -> Exec['splunkforwarder-install-package'] -> Exec['splunkforwarder-enable-boot-start-after-upgrade']
+      }
+    }
+
+    $_splunk_home_always = $splunk::forwarder::forwarder_homedir
+    $_splunk_user_always = $splunk::forwarder::splunk_user
+
+    exec { 'splunkforwarder-fix-ownership-always':
+      command => "/bin/chown -R ${_splunk_user_always}:${_splunk_user_always} ${_splunk_home_always}",
+      onlyif  => "/usr/bin/test -d ${_splunk_home_always} && /usr/bin/stat -c '%G' ${_splunk_home_always} | grep -v '^${_splunk_user_always}$'",
+      timeout => 120,
+    }
+  }
 }

--- a/manifests/forwarder/service/nix.pp
+++ b/manifests/forwarder/service/nix.pp
@@ -19,7 +19,12 @@ class splunk::forwarder::service::nix inherits splunk::forwarder::service {
       notify  => Exec['enable_splunkforwarder'],
     }
 
-    $user_args = "-user ${splunk::forwarder::splunk_user}"
+    $user_args = "-user ${splunk::forwarder::splunk_user} -group ${splunk::forwarder::splunk_user}"
+
+    $user_args_full = $splunk::params::boot_start_args ? {
+      ''      => $user_args,
+      default => "${user_args} ${splunk::params::boot_start_args}",
+    }
 
     if $facts['kernel'] == 'SunOS' {
       Service[$splunk::forwarder::service_name] {
@@ -31,9 +36,10 @@ class splunk::forwarder::service::nix inherits splunk::forwarder::service {
     # unit files during uninstallation, so you may be required to manually
     # remove existing unit files before re-installing and enabling boot-start.
     exec { 'enable_splunkforwarder':
-      command     => "${splunk::forwarder::forwarder_homedir}/bin/splunk enable boot-start ${user_args} ${splunk::params::boot_start_args} --accept-license --answer-yes --no-prompt",
+      command     => "${splunk::forwarder::forwarder_homedir}/bin/splunk enable boot-start ${user_args_full} --accept-license --answer-yes --no-prompt",
       tag         => 'splunk_forwarder',
       refreshonly => true,
+      returns     => [0, 4],
       before      => Service[$splunk::forwarder::service_name],
       require     => Exec['stop_splunkforwarder'],
     }

--- a/spec/classes/forwarder_spec.rb
+++ b/spec/classes/forwarder_spec.rb
@@ -137,7 +137,7 @@ describe 'splunk::forwarder' do
               it { is_expected.to contain_class('splunk::forwarder::service::nix') }
               it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'splunk') }
               it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop') }
-              it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
+              it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root -group root --accept-license --answer-yes --no-prompt') }
               it { is_expected.not_to contain_exec('disable_splunkforwarder') }
               it { is_expected.not_to contain_exec('license_splunkforwarder') }
               it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
@@ -155,7 +155,7 @@ describe 'splunk::forwarder' do
               it { is_expected.to contain_class('splunk::forwarder::service::nix') }
               it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'splunk') }
               it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop') }
-              it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
+              it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root -group root --accept-license --answer-yes --no-prompt') }
               it { is_expected.not_to contain_exec('disable_splunkforwarder') }
               it { is_expected.not_to contain_exec('license_splunkforwarder') }
               it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
@@ -173,7 +173,7 @@ describe 'splunk::forwarder' do
               it { is_expected.to contain_class('splunk::forwarder::service::nix') }
               it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'SplunkForwarder') }
               it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop') }
-              it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
+              it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root -group root -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
               it { is_expected.not_to contain_exec('disable_splunkforwarder') }
               it { is_expected.not_to contain_exec('license_splunkforwarder') }
               it { is_expected.to contain_service('SplunkForwarder').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }
@@ -188,7 +188,7 @@ describe 'splunk::forwarder' do
               end
               let(:params) { { splunk_user: 'splunk' } }
 
-              it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user splunk -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
+              it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user splunk -group splunk -systemd-managed 1 --accept-license --answer-yes --no-prompt') }
             end
 
             context 'with $facts[service_provider] == systemd and $splunk::params::version < 7.2.2' do
@@ -203,7 +203,7 @@ describe 'splunk::forwarder' do
               it { is_expected.to contain_class('splunk::forwarder::service::nix') }
               it { is_expected.to contain_class('splunk::forwarder').with(service_name: 'splunk') }
               it { is_expected.to contain_exec('stop_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk stop') }
-              it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root  --accept-license --answer-yes --no-prompt') }
+              it { is_expected.to contain_exec('enable_splunkforwarder').with(command: '/opt/splunkforwarder/bin/splunk enable boot-start -user root -group root --accept-license --answer-yes --no-prompt') }
               it { is_expected.not_to contain_exec('disable_splunkforwarder') }
               it { is_expected.not_to contain_exec('license_splunkforwarder') }
               it { is_expected.to contain_service('splunk').with(ensure: 'running', enable: true, status: nil, restart: nil, start: nil, stop: nil) }


### PR DESCRIPTION
- Add upgrade logic in install.pp to detect version changes and handle stop/disablebootstart/install/enablebootstart/fixownership
- Add -group to boot-start in service/nix.pp to set correct group
- Fix ownership of TA app files after archive extraction in addon.pp
- Add systemd symlink fix after boot-start enable in service/nix.pp

---
*PR sponsored by [Obmondo.com](https://obmondo.com)*

---

**Note:** Since this is a company-paid contribution, we fork to the company
account repo on GitHub. GitHub does not support "allow maintainer to edit
in repo" for organization accounts.

- Maintainers can either provide feedback for required changes before merging, OR
- Pull our branch, make changes in their repo, and create a new PR including our commits.