### PR TITLE
Fix type sync for multi-value `ini_setting` results

### DIFF
--- a/lib/puppet_x/puppetlabs/splunk/type.rb
+++ b/lib/puppet_x/puppetlabs/splunk/type.rb
@@ -33,12 +33,24 @@ module PuppetX
             def insync?(is) # rubocop:disable Lint/NestedMethodDefinition
               secrets_file_path = File.join(provider.class.file_path, 'auth/splunk.secret')
               secrets_file_exist = File.file?(secrets_file_path)
-              if !should.start_with?('$7$') && secrets_file_exist
-                PuppetX::Voxpupuli::Splunk::Util.decrypt(secrets_file_path, is) == should
-              else
-                Puppet.warning("Secrets file NOT found in #{secrets_file_path}") unless secrets_file_exist
-                is == should
+
+              current_values = normalize_values(is, secrets_file_path, secrets_file_exist)
+              desired_values = normalize_values(should, secrets_file_path, false)
+
+              current_values == desired_values
+            end
+
+            def normalize_values(value, secrets_file_path, secrets_file_exist) # rubocop:disable Lint/NestedMethodDefinition
+              Array(value).map do |v|
+                if secrets_file_exist && v.is_a?(String) && !encrypted?(should)
+                  PuppetX::Voxpupuli::Splunk::Util.decrypt(secrets_file_path, v)
+                else
+                  v
+                end
               end
+            end
+            def encrypted?(value) # rubocop:disable Lint/NestedMethodDefinition
+              value.is_a?(String) && value.start_with?('$7$')
             end
           end
           type.newparam(:setting) do

--- a/lib/puppet_x/puppetlabs/splunk/type.rb
+++ b/lib/puppet_x/puppetlabs/splunk/type.rb
@@ -34,6 +34,8 @@ module PuppetX
               secrets_file_path = File.join(provider.class.file_path, 'auth/splunk.secret')
               secrets_file_exist = File.file?(secrets_file_path)
 
+              Puppet.warning("Secrets file NOT found in #{secrets_file_path}") unless secrets_file_exist
+              
               current_values = normalize_values(is, secrets_file_path, secrets_file_exist)
               desired_values = normalize_values(should, secrets_file_path, false)
 

--- a/lib/puppet_x/puppetlabs/splunk/type.rb
+++ b/lib/puppet_x/puppetlabs/splunk/type.rb
@@ -35,7 +35,7 @@ module PuppetX
               secrets_file_exist = File.file?(secrets_file_path)
 
               Puppet.warning("Secrets file NOT found in #{secrets_file_path}") unless secrets_file_exist
-              
+
               current_values = normalize_values(is, secrets_file_path, secrets_file_exist)
               desired_values = normalize_values(should, secrets_file_path, false)
 

--- a/lib/puppet_x/puppetlabs/splunk/type.rb
+++ b/lib/puppet_x/puppetlabs/splunk/type.rb
@@ -42,15 +42,12 @@ module PuppetX
 
             def normalize_values(value, secrets_file_path, secrets_file_exist) # rubocop:disable Lint/NestedMethodDefinition
               Array(value).map do |v|
-                if secrets_file_exist && v.is_a?(String) && !encrypted?(should)
+                if !should.start_with?('$7$') && v.is_a?(String) && secrets_file_exist
                   PuppetX::Voxpupuli::Splunk::Util.decrypt(secrets_file_path, v)
                 else
                   v
                 end
               end
-            end
-            def encrypted?(value) # rubocop:disable Lint/NestedMethodDefinition
-              value.is_a?(String) && value.start_with?('$7$')
             end
           end
           type.newparam(:setting) do

--- a/lib/puppet_x/voxpupuli/splunk/util.rb
+++ b/lib/puppet_x/voxpupuli/splunk/util.rb
@@ -8,7 +8,7 @@ module PuppetX
     module Splunk
       class Util
         def self.decrypt(secrets_file, value)
-          return value unless value.start_with?('$7$')
+          return value unless value.is_a?(String) && value.start_with?('$7$')
 
           Puppet.debug "Decrypting splunk >= 7.2 data using secret from #{secrets_file}"
           data = Base64.strict_decode64(value[3..-1])

--- a/spec/unit/puppet/type/splunk_types_spec.rb
+++ b/spec/unit/puppet/type/splunk_types_spec.rb
@@ -110,6 +110,18 @@ SPLUNK_TYPES.each do |type, file_name|
           allow(IO).to receive(:binread).with(%r{/opt/splunk(forwarder)?/etc/auth/splunk\.secret$}).and_return('JX7cQAnH6Nznmild8MvfN8/BLQnGr8C3UYg3mqvc3ArFkaxj4gUt1RUCaRBD/r0CNn8xOA2oKX8/0uyyChyGRiFKhp6h2FA+ydNIRnN46N8rZov8QGkchmebZa5GAM5U50GbCCgzJFObPyWi5yT8CrSCYmv9cpRtpKyiX+wkhJwltoJzAxWbBERiLp+oXZnN3lsRn6YkljmYBqN9tZLTVVpsLvqvkezPgpv727Fd//5dRoWsWBv2zRp0mwDv3tj')
           expect(property).to be_safe_insync('$7$aTVkS01HYVNJUk5wSnR5NIu4GXLhj2Qd49n2B6Y8qmA/u1CdL9JYxQ==')
         end
+        
+        it 'is insync if `is` is a single-element array matching `should`' do
+          property.should = 'value'
+          expect(property).to be_safe_insync(['value'])
+        end
+
+        it 'is insync if encrypted values in `is` are returned as an array and decrypt to `should`' do
+          property.should = 'temp1234'
+          allow(File).to receive(:file?).with(%r{/opt/splunk(forwarder)?/etc/auth/splunk\.secret$}).and_return(true)
+          allow(IO).to receive(:binread).with(%r{/opt/splunk(forwarder)?/etc/auth/splunk\.secret$}).and_return('JX7cQAnH6Nznmild8MvfN8/BLQnGr8C3UYg3mqvc3ArFkaxj4gUt1RUCaRBD/r0CNn8xOA2oKX8/0uyyChyGRiFKhp6h2FA+ydNIRnN46N8rZov8QGkchmebZa5GAM5U50GbCCgzJFObPyWi5yT8CrSCYmv9cpRtpKyiX+wkhJwltoJzAxWbBERiLp+oXZnN3lsRn6YkljmYBqN9tZLTVVpsLvqvkezPgpv727Fd//5dRoWsWBv2zRp0mwDv3tj')
+          expect(property).to be_safe_insync(['$7$aTVkS01HYVNJUk5wSnR5NIu4GXLhj2Qd49n2B6Y8qmA/u1CdL9JYxQ=='])
+        end
       end
     end
   end

--- a/spec/unit/puppet/type/splunk_types_spec.rb
+++ b/spec/unit/puppet/type/splunk_types_spec.rb
@@ -110,7 +110,7 @@ SPLUNK_TYPES.each do |type, file_name|
           allow(IO).to receive(:binread).with(%r{/opt/splunk(forwarder)?/etc/auth/splunk\.secret$}).and_return('JX7cQAnH6Nznmild8MvfN8/BLQnGr8C3UYg3mqvc3ArFkaxj4gUt1RUCaRBD/r0CNn8xOA2oKX8/0uyyChyGRiFKhp6h2FA+ydNIRnN46N8rZov8QGkchmebZa5GAM5U50GbCCgzJFObPyWi5yT8CrSCYmv9cpRtpKyiX+wkhJwltoJzAxWbBERiLp+oXZnN3lsRn6YkljmYBqN9tZLTVVpsLvqvkezPgpv727Fd//5dRoWsWBv2zRp0mwDv3tj')
           expect(property).to be_safe_insync('$7$aTVkS01HYVNJUk5wSnR5NIu4GXLhj2Qd49n2B6Y8qmA/u1CdL9JYxQ==')
         end
-        
+
         it 'is insync if `is` is a single-element array matching `should`' do
           property.should = 'value'
           expect(property).to be_safe_insync(['value'])


### PR DESCRIPTION
## Summary

Fix `insync?` handling when `puppetlabs-inifile` returns array values for repeated keys.

This avoids agent fails like:

```text
Error: undefined method `start_with?' for ["127.0.0.1:8089"]:Array
/opt/puppetlabs/puppet/cache/lib/puppet_x/voxpupuli/splunk/util.rb:11:in `decrypt'
/opt/puppetlabs/puppet/cache/lib/puppet_x/puppetlabs/splunk/type.rb:37:in `insync?'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/property.rb:277:in `safe_insync?'
...
```

## Changes

- normalize is and should before comparison
- treat "value" and ["value"] as equivalent
- harden decryption against non-string input

## Context
This appears to be triggered by support for multiple values per key in:
puppetlabs/puppetlabs-inifile#555


_This pull request was prepared with assistance from GitHub Copilot._